### PR TITLE
const-correct output methods

### DIFF
--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -588,7 +588,7 @@ public final class Connection: ConnectionBase
     ***************************************************************************/
 
     override protected void getPayloadForSending (
-        RequestId id, void delegate ( void[][] payload ) send
+        RequestId id, void delegate ( in void[][] payload ) send
     )
     {
         if (auto request_handler = this.getRequestOnConn(id))

--- a/src/swarm/neo/client/IRequestSet.d
+++ b/src/swarm/neo/client/IRequestSet.d
@@ -59,7 +59,7 @@ interface IRequest
 
 interface IRequestOnConn
 {
-    void getPayloadForSending ( void delegate ( void[][] payload ) send );
+    void getPayloadForSending ( void delegate ( in void[][] payload ) send );
     void setReceivedPayload ( Const!(void)[] payload );
     void error ( Exception e );
     void reconnected ( );

--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -595,7 +595,7 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
 
     ***************************************************************************/
 
-    override public void getPayloadForSending ( void delegate ( void[][] payload ) send )
+    override public void getPayloadForSending ( void delegate ( in void[][] payload ) send )
     {
         super.getPayloadForSending(send);
     }

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -353,7 +353,7 @@ abstract class ConnectionBase: ISelectClient
 
             this.outer.getPayloadForSending(
                 id,
-                ( void[][] payload )
+                ( in void[][] payload )
                 {
                     finish_sending = this.outer.sender.assign(
                         MessageType.Request, payload,
@@ -1024,7 +1024,7 @@ abstract class ConnectionBase: ISelectClient
     ***************************************************************************/
 
     abstract protected void getPayloadForSending ( RequestId id,
-        void delegate ( void[][] payload ) send );
+        void delegate ( in void[][] payload ) send );
 
     /***************************************************************************
 

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -348,9 +348,9 @@ abstract class RequestOnConnBase
 
             *******************************************************************/
 
-            public void addArray ( T ) ( ref T[] arr )
+            public void addArray ( T: Element[], Element ) ( ref T arr )
             {
-                static assert(!hasIndirections!(T));
+                static assert(!hasIndirections!(Element));
 
                 /*
                  * arr is a dynamic array. To slice the data of arr.length, we
@@ -382,7 +382,7 @@ abstract class RequestOnConnBase
                 this.outer.outer.send_payload ~=
                     (cast(void*)&arr)[0..size_t.sizeof];
                 this.outer.outer.send_payload ~=
-                    (cast(void*)arr.ptr)[0..arr.length * T.sizeof];
+                    (cast(void*)arr.ptr)[0..arr.length * Element.sizeof];
             }
 
             /*******************************************************************

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -300,7 +300,7 @@ abstract class RequestOnConnBase
             public void add ( T ) ( ref T elem )
             {
                 static assert(!hasIndirections!(T));
-                this.outer.outer.send_payload ~= (cast(void*)&elem)[0..T.sizeof];
+                this.outer.outer.send_payload ~= (cast(Const!(void*))&elem)[0..T.sizeof];
             }
 
             /*******************************************************************
@@ -380,9 +380,9 @@ abstract class RequestOnConnBase
                  * variable.
                  */
                 this.outer.outer.send_payload ~=
-                    (cast(void*)&arr)[0..size_t.sizeof];
+                    (cast(Const!(void)*)&arr)[0..size_t.sizeof];
                 this.outer.outer.send_payload ~=
-                    (cast(void*)arr.ptr)[0..arr.length * Element.sizeof];
+                    (cast(Const!(void)*)arr.ptr)[0..arr.length * Element.sizeof];
             }
 
             /*******************************************************************
@@ -394,10 +394,10 @@ abstract class RequestOnConnBase
 
             unittest
             {
-                void[][] slices;
-                mstring arr = "Hello World!".dup;
-                slices ~= (cast(void*)&arr)[0..size_t.sizeof];
-                slices ~= (cast(void*)arr.ptr)[0..arr.length];
+                Const!(void)[][] slices;
+                istring arr = "Hello World!";
+                slices ~= (cast(Const!(void)*)&arr)[0..size_t.sizeof];
+                slices ~= (cast(Const!(void)*)arr.ptr)[0..arr.length];
                 assert(slices.length == 2);
                 assert(slices[0].length == size_t.sizeof);
                 assert(*cast(size_t*)(slices[0].ptr) == arr.length);

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -119,7 +119,7 @@ abstract class RequestOnConnBase
 
     ***************************************************************************/
 
-    protected void[][] send_payload_;
+    protected Const!(void[])[] send_payload_;
 
     /***************************************************************************
 
@@ -128,7 +128,7 @@ abstract class RequestOnConnBase
 
     ***************************************************************************/
 
-    private void[][] send_payload;
+    private Const!(void)[][] send_payload;
 
     /***************************************************************************
 
@@ -520,7 +520,7 @@ abstract class RequestOnConnBase
 
         ***********************************************************************/
 
-        public void send ( void[][] payload ... )
+        public void send ( in void[][] payload ... )
         {
             int resume_code = this.sendAndHandleEvents(payload);
             assert(resume_code <= 0, "send: User unexpectedy resumed the fiber");
@@ -580,7 +580,7 @@ abstract class RequestOnConnBase
 
         ***********************************************************************/
 
-        public int sendAndHandleEvents ( void[][] payload ... )
+        public int sendAndHandleEvents ( in void[][] payload ... )
         in
         {
             assert(payload.length, "sendAndHandleEvents: no payload to send");
@@ -1085,7 +1085,7 @@ abstract class RequestOnConnBase
 
         public void sendReceive (
             void delegate ( in void[] payload ) received,
-            void[][] payload ...
+            in void[][] payload ...
         )
         in
         {
@@ -1166,7 +1166,7 @@ abstract class RequestOnConnBase
 
         public int sendReceiveAndHandleEvents (
             void delegate ( in void[] recv_payload ) received,
-            void[][] payload ...
+            in void[][] payload ...
         )
         in
         {
@@ -1391,7 +1391,7 @@ abstract class RequestOnConnBase
 
     ***************************************************************************/
 
-    protected void getPayloadForSending ( void delegate ( void[][] payload ) send )
+    protected void getPayloadForSending ( void delegate ( in void[][] payload ) send )
     {
         try
             send(this.send_payload_);

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -240,7 +240,7 @@ class Connection: ConnectionBase
     ***************************************************************************/
 
     override protected void getPayloadForSending (
-        RequestId id, void delegate ( void[][] payload ) send
+        RequestId id, void delegate ( in void[][] payload ) send
     )
     {
         if (auto request = this.request_set.getRequest(id))

--- a/src/swarm/neo/node/RequestSet.d
+++ b/src/swarm/neo/node/RequestSet.d
@@ -131,7 +131,7 @@ class RequestSet
 
         ***********************************************************************/
 
-        override public void getPayloadForSending ( void delegate ( void[][] payload ) send )
+        override public void getPayloadForSending ( void delegate ( in void[][] payload ) send )
         {
             super.getPayloadForSending(send);
         }

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -52,7 +52,7 @@ struct IoVecMessage // MessageGenerator
 
     ***************************************************************************/
 
-    IoVecTracker* setup ( MessageType type, void[][] dynamic_fields, void[][] static_fields ... )
+    IoVecTracker* setup ( MessageType type, in void[][] dynamic_fields, in void[][] static_fields ... )
     in
     {
         assert(type <= type.max);

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -131,7 +131,7 @@ struct IoVecMessage // MessageGenerator
 
 struct IoVecTracker
 {
-    import core.sys.posix.sys.uio: iovec;
+    import swarm.neo.protocol.socket.uio_const: iovec_const;
     import ocean.transition: enableStomping;
 
     /***************************************************************************
@@ -143,7 +143,7 @@ struct IoVecTracker
 
     ***************************************************************************/
 
-    iovec[] fields;
+    iovec_const[] fields;
 
     /***************************************************************************
 
@@ -264,7 +264,7 @@ struct IoVecTracker
             assert(start == this.length);
 
             this.fields = this.fields[0 .. 1];
-            this.fields[0] = iovec(dst.ptr, this.length);
+            this.fields[0] = iovec_const(dst.ptr, this.length);
         }
         else if (dst)
         {
@@ -290,18 +290,18 @@ struct IoVecTracker
                e = "Treppe".dup,
                f = "krumm".dup;
 
-        iovec[6] iovecs = void;
+        iovec_const[6] iovecs = void;
 
         This iov;
 
         void setup ( )
         {
-            iovecs[0] = iovec(a.ptr, a.length);
-            iovecs[1] = iovec(b.ptr, b.length);
-            iovecs[2] = iovec(c.ptr, c.length);
-            iovecs[3] = iovec(d.ptr, d.length);
-            iovecs[4] = iovec(e.ptr, e.length);
-            iovecs[5] = iovec(f.ptr, f.length);
+            iovecs[0] = iovec_const(a.ptr, a.length);
+            iovecs[1] = iovec_const(b.ptr, b.length);
+            iovecs[2] = iovec_const(c.ptr, c.length);
+            iovecs[3] = iovec_const(d.ptr, d.length);
+            iovecs[4] = iovec_const(e.ptr, e.length);
+            iovecs[5] = iovec_const(f.ptr, f.length);
 
             foreach (field; iov.fields = iovecs)
             {
@@ -309,7 +309,7 @@ struct IoVecTracker
             }
         }
 
-        void[] iovField ( size_t i )
+        Const!(void)[] iovField ( size_t i )
         {
             with (iov.fields[i]) return iov_base[0 .. iov_len];
         }

--- a/src/swarm/neo/protocol/socket/MessageSender.d
+++ b/src/swarm/neo/protocol/socket/MessageSender.d
@@ -26,8 +26,8 @@ class MessageSender
 
     import ocean.io.select.protocol.generic.ErrnoIOException: IOError;
 
+    import swarm.neo.protocol.socket.uio_const;
     import core.sys.posix.sys.socket: setsockopt;
-    import core.sys.posix.sys.uio: iovec, writev;
     import core.sys.posix.netinet.in_: IPPROTO_TCP;
     import core.sys.linux.sys.netinet.tcp: TCP_CORK;
     import core.stdc.errno: errno, EAGAIN, EWOULDBLOCK, EINTR;
@@ -144,7 +144,7 @@ class MessageSender
 
     public bool assignProtocolVersion ( ubyte protocol_version )
     {
-        auto iov = iovec(&protocol_version, protocol_version.sizeof);
+        auto iov = iovec_const(&protocol_version, protocol_version.sizeof);
         auto tracker = IoVecTracker((&iov)[0 .. 1], iov.iov_len);
         return this.assign_(tracker);
     }
@@ -217,7 +217,7 @@ class MessageSender
     }
     body
     {
-        auto iov = iovec(this.pending_data.ptr, this.pending_data.length);
+        auto iov = iovec_const(this.pending_data.ptr, this.pending_data.length);
         auto src = IoVecTracker((&iov)[0 .. 1], iov.iov_len);
 
         scope (exit)
@@ -388,7 +388,7 @@ class MessageSender
 
         errno = 0;
 // maybe do the vector I/O call + advance in IoVecTracker?
-        socket.ssize_t n = writev(this.socket.fd, src.fields.ptr, cast(int)src.fields.length);
+        socket.ssize_t n = sendv(this.socket.fd, src.fields);
 
         if (n >= 0) // n == 0 cannot happen: write() returns it only if the
         {           // output data are empty, which we prevent in the precondition

--- a/src/swarm/neo/protocol/socket/MessageSender.d
+++ b/src/swarm/neo/protocol/socket/MessageSender.d
@@ -179,7 +179,7 @@ class MessageSender
 
      **************************************************************************/
 
-    public bool assign ( MessageType type, void[][] dynamic_fields, void[][] static_fields ... )
+    public bool assign ( MessageType type, in void[][] dynamic_fields, in void[][] static_fields ... )
     {
         auto tracker = this.iov_msg.setup(type, dynamic_fields, static_fields);
         this.io_stats.msg_body.countBytes(tracker.length - MessageHeader.sizeof);

--- a/src/swarm/neo/protocol/socket/uio_const.d
+++ b/src/swarm/neo/protocol/socket/uio_const.d
@@ -1,0 +1,165 @@
+/*******************************************************************************
+
+    D-`const`-correct vector/gather socket output with optional `SIGPIPE`
+    suppression.
+
+    Copyright: Copyright (c) 2015-2017 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+
+*******************************************************************************/
+
+module swarm.neo.protocol.socket.uio_const;
+
+import core.sys.posix.sys.types: ssize_t;
+
+import core.sys.posix.sys.socket;
+
+import ocean.transition;
+
+/*******************************************************************************
+
+    D-`const`-correct output version of `iovec`. It is used like `iovec` for
+    functions that only read the data referenced by `iov_base`, i.e. output
+    functions. It fixes the following problem:
+
+    ```
+        int socket_fd;
+
+        // Define some read-only data to pass to sendv.
+        auto a = "Hello", b = "World";
+
+        // Declare an output vector
+        iovec[2] output_vec;
+
+        // Set the output vector components to reference the read-only data.
+        output_vec[0].iov_base = a.ptr;     // Problem
+        output_vec[0].iov_len  = a.length;
+        output_vec[1].iov_base = b.ptr;     // Problem
+        output_vec[1].iov_len  = b.length;
+
+        // Send the output data i.e. a ~ b through the socket.
+        auto bytes_sent = sendv(socket_fd, output_vec);
+    ```
+
+    The problem here is that the type of `iovec.iov_base` is (mutable) `void*`
+    but we need it to reference read-only string data of type `immutable(char)`.
+    This is illegal. We need `iovec.iov_base` to be of type `const(void)*`.
+
+    Seemingly, a solution would be to declare `const(iovec)[2] output_vec`. But
+    that would cause another problem: `sendv` may only send a part of the output
+    data, in which case `bytes_sent` would be less than
+    `output_vec[0].iov_len + output_vec[1].iov_len`, and we need to adjust the
+    elements of `output_vec` to reference the remaining data and pass them to
+    another `sendv` call, and we need to do this in a loop until `sendv` has
+    sent all data referenced by `output_vec`. If the elements of `output_vec`
+    are now of type `const(iovec)` then we cannot modify them in-place but would
+    have to create copies on every cycle of the loop. Although this would be
+    possible it would cause unnecessary memory allocations in a potentially
+    performance critical code location.
+
+    So there is a need for `iovec_const`, an `iovec` equivalent with `iov_base`
+    of type `const(void)*`.
+
+    A little more background information: `iovec` is part of the `uio` POSIX API
+    for I/O functions performing so-called "vector I/O" or "scatter input
+    gather output". Expressed in D, they accept a `void[][]` array, called
+    "vector", of I/O data buffers (rather than one `void[]` I/O data buffer like
+    ordinary I/O functions) and write input data to or read output data from
+    these buffers, resp., in the order of appearance.
+
+    http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_uio.h.html
+
+    The most primitive functions of this family are
+    ```
+        ssize_t readv(int fd, in iovec* iov, int iovcnt);
+        ssize_t preadv(int fd, in iovec* iov, int iovcnt, off_t offset);
+        ssize_t writev(int fd, in iovec* iov, int iovcnt);
+        ssize_t pwritev(int fd, in iovec* iov, int iovcnt, off_t offset);
+    ```
+    These functions accept an `iovec[] data` array in the way that
+    `iov = data.ptr` and `iovcnt = data.length`.
+    More advanced functions include
+    ```
+         ssize_t recvmsg(int sockfd, scope msghdr* msg, int flags);
+         ssize_t sendmsg(int sockfd, in msghdr* msg, int flags);
+    ```
+    where `msghdr` is a struct containing the fields
+    ```
+        iovec* msg_iovec;
+        size_t msg_iovlen;
+    ```
+    which is again an `iovec[]` array with `msg_iovec = ptr` and
+    `msg_iovlen = length`. The `sendv` function in this module is a wrapper for
+    `sendmsg`.
+
+    All functions in this API have in common that they use the same `iovec`
+    array pointer type for both input and output functions where the input
+    functions do write-only access to the data referenced by the `iov_base`
+    fields of the `iovec` struct instances involved and the output functions
+    read-only. None of the output functions is `const`-correct, all of them
+    should use alternative struct definitions with `const(void)*` pointers
+    referencing the output data.
+
+    Unfortunately this API was not designed with `const` in mind.
+
+*******************************************************************************/
+
+struct iovec_const
+{
+    Const!(void)* iov_base;
+    size_t iov_len;
+}
+
+/*******************************************************************************
+
+    This is a `const`-correct hybrid of `send(2)` and `writev(2)`:
+    - Like `send` it works only with a connection-mode socket and accepts the
+      same flags as `send`.
+    - Like `writev` it performs gather-output, accepting a vector (i.e. array)
+      of output buffers, which is, in contrast to `writev(2)`,
+      D-`const`-correct.
+
+    Params:
+        socket_fd = the socket file descriptor
+        data      = the output data, see the `writev(2)` docu for details
+        flags     = `MSG_*` flags; see `send(2)` documentation
+
+    Returns:
+        0 on success or -1 on failure, in which case `errno` is set accordingly.
+
+*******************************************************************************/
+
+ssize_t sendv ( int socket_fd, in iovec_const[] data, int flags = 0 )
+{
+    Const!(msghdr) m = {
+            msg_iov:    cast(Const!(iovec*))data.ptr,
+            msg_iovlen: data.length
+    };
+    return sendmsg(socket_fd, &m, flags);
+}
+
+// Ensure binary compatibility of `iovec_const` with `iovec`.
+unittest
+{
+    static assert(iovec_const.sizeof == iovec.sizeof);
+    static assert(iovec_const.alignof == iovec.alignof);
+
+    alias typeof(iovec.tupleof)       iovecFields;
+    alias typeof(iovec_const.tupleof) iovec_constFields;
+    static assert(iovec_constFields.length == iovecFields.length);
+
+    foreach (i, iovec_constField; iovec_constFields)
+    {
+        static if (is(iovec_constField == Const!(void)*))
+            static assert(is(iovecFields[i] == void*));
+        else
+            static assert(is(iovec_constField == iovecFields[i]));
+
+        static assert(iovec_const.tupleof[i].offsetof ==
+                      iovec.tupleof[i].offsetof);
+        static assert(iovec_const.tupleof[i].alignof ==
+                      iovec.tupleof[i].alignof);
+    }
+}


### PR DESCRIPTION
Change the types of output buffers to `const`, all the way from the `RequestOnConn` API methods down to the socket output function.