### PR TITLE
Add IListener.Code.Deletion trigger code

### DIFF
--- a/relnotes/listen-delete.feature.md
+++ b/relnotes/listen-delete.feature.md
@@ -1,0 +1,8 @@
+* `swarm.node.storage.listeners.Listeners`
+
+  The `Code` enum in `IListener` has a new member -- `Deletion` -- which may be
+  triggered by the storage engine when a record is removed.
+
+  (Note that, as the storage engine implementation is solely responsible for
+  triggering the listener codes, the addition of this enum member is not a
+  breaking change.)

--- a/src/swarm/node/storage/listeners/Listeners.d
+++ b/src/swarm/node/storage/listeners/Listeners.d
@@ -53,6 +53,7 @@ public interface IListener
     {
         None = 0,
         DataReady,  // a record is ready for reading
+        Deletion,   // a record has been deleted
         Flush,      // the write buffer should be flushed
         Finish      // the listener should stop listening (e.g. in the case when
                     // the listen source is about to disappear


### PR DESCRIPTION
May be used to indicate record removals from the storage engine.