### PR TITLE
Add gitignore and neptune.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+Config.local.mak

--- a/.neptune.yml
+++ b/.neptune.yml
@@ -1,0 +1,2 @@
+library: true
+d2ready: true


### PR DESCRIPTION
Those files where in the private repository, but didn't make it to the open-source one.

CC @mihails-strasuns-sociomantic : Tsunami swarm is not part of the neptune overview.