### PR TITLE
Remove unused import

### DIFF
--- a/src/swarm/util/log/ClientStats.d
+++ b/src/swarm/util/log/ClientStats.d
@@ -45,8 +45,6 @@ import ocean.util.log.Log;
 
 import ocean.util.log.Stats;
 
-import ocean.text.convert.Layout;
-
 import swarm.Const : NodeItem;
 
 import swarm.client.model.IClient;


### PR DESCRIPTION
This will soon be deprecated in ocean, so removing it here pre-emptively.