### PR TITLE
Fix compilation of ClientCore when RequestStats not instantiated

### DIFF
--- a/relnotes/log-client-stats.feature.md
+++ b/relnotes/log-client-stats.feature.md
@@ -1,6 +1,6 @@
 * `swarm.neo.client.mixins.ClientCore`
 
-  New functions `logStatsFromAggregate` and `logRequestStats` have been added to
-  the core neo client to help with writing client info to a stats logger
-  (`ocean.util.log.Stats`). See usage examples in the code.
+  New functions `logStatsFromAggregate` and `RequestStatsTemplate.log` have been
+  added to the core neo client to help with writing client info to a stats
+  logger (`ocean.util.log.Stats`). See usage examples in the code.
 

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -562,30 +562,20 @@ template ClientCore ( )
         {
             this.outer.connections.request_set.stats.clear();
         }
-    }
 
-    /***************************************************************************
+        /***********************************************************************
 
-        Writes stats about all requests to the provided stats log.
+            Writes stats about all requests to the provided stats log.
 
-        Params:
-            logger = stats log to write the filled instance of Aggr to
+            Params:
+                logger = stats log to write the filled instance of Aggr to
 
-    ***************************************************************************/
+        ***********************************************************************/
 
-    private void logRequestStats ( StatsLog logger )
-    {
-        scope rq_stats = this.new RequestStats;
-        foreach ( rq, stats; rq_stats.allRequests() )
-            logger.addObject!("request")(rq, stats);
-    }
-
-    ///
-    unittest
-    {
-        void logClientRequestStats ( typeof(this) client, StatsLog logger )
+        private void log ( StatsLog logger )
         {
-            client.logRequestStats(logger);
+            foreach ( rq, stats; this.allRequests() )
+                logger.addObject!("request")(rq, stats);
         }
     }
 


### PR DESCRIPTION
(Bug fix for unreleased code in v4.x.x.)

The method logRequestStats assumed that a class called RequestStats exists.
This is not always the case. It's safer to put the logging method inside
RequestStatsTemplate, so it can only be called when the template is
instantiated.