### PR TITLE
Enable socket output buffering and enable request handlers to flush the buffer

### DIFF
--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -105,6 +105,16 @@ abstract class ConnectionBase: ISelectClient
 
         /***********************************************************************
 
+            If this flag is true and `sendRequestPayload` is waiting for
+            `EPOLLOUT` then it will call `sender.flush` after it has sent the
+            remaining data.
+
+        ***********************************************************************/
+
+        public bool flush_requested;
+
+        /***********************************************************************
+
             The queue of ids of requests waiting to send a message.
 
         ***********************************************************************/
@@ -353,6 +363,8 @@ abstract class ConnectionBase: ISelectClient
         {
             bool finish_sending = false;
 
+            scope (exit) this.flush_requested = false;
+
             this.outer.getPayloadForSending(
                 id,
                 ( in void[][] payload )
@@ -369,6 +381,8 @@ abstract class ConnectionBase: ISelectClient
                 // Register the socket for both input and output
                 this.outer.registerEpoll(true);
                 this.outer.sender.finishSending(this.suspend());
+                if (this.flush_requested)
+                    this.outer.sender.flush();
             }
         }
     }
@@ -1056,6 +1070,31 @@ abstract class ConnectionBase: ISelectClient
 
     abstract protected void getPayloadForSending ( RequestId id,
         void delegate ( in void[][] payload ) send );
+
+    /***************************************************************************
+
+        Requests to send outgoing data buffered by the OS for the socket
+        immediately. By default outgoing data are buffered to the maximum
+        payload of a TCP frame using the Linux TCP_CORK socket option.
+
+        This method is intended to be called right after `getPayloadForSending`
+        has called the `send` delegate.
+
+    ***************************************************************************/
+
+    public void flush ( )
+    {
+        // Flush the OS-maintained (TCP_CORK) socket output buffer. This will
+        // immediately send all data that have been accepted by `sendmsg(2)`.
+        this.sender.flush();
+        // `this.sender` may in addition buffer data that have not been accepted
+        // by `sendmsg` - that is, `send(2)` returned a value less than the
+        // buffer length argument - and wait for `EPOLLOUT` on the socket to
+        // call `sendmsg` again  with the remaining data. Set a flag to flush
+        // the OS-maintained (TCP_CORK) socket output buffer when `sendmsg`
+        // eventually accepted all outstanding data.
+        this.send_loop.flush_requested = true;
+    }
 
     /***************************************************************************
 

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -262,6 +262,8 @@ abstract class ConnectionBase: ISelectClient
 
                 try
                 {
+                    this.outer.sender.cork = true;
+
                     // Start the receive fiber, it will suspend itself immediately.
                     this.outer.recv_loop.start();
 

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -482,6 +482,19 @@ abstract class RequestOnConnBase
 
         /***********************************************************************
 
+            Requests to send outgoing data buffered by the OS for the socket
+            immediately. By default outgoing data are buffered to the maximum
+            payload of a TCP frame using the Linux TCP_CORK socket option.
+
+        ***********************************************************************/
+
+        public void flush ( )
+        {
+            this.outer.connection.flush();
+        }
+
+        /***********************************************************************
+
             Sends a message for this request to the node.
 
             Do not resume the fiber before this method has returned or thrown.


### PR DESCRIPTION
Enable buffering outgoing data on the socket via TCP Cork and add `RequestOnConnBase.flush()` for request handlers to flush the buffer if needed.

For the record, TCP Cork  is a socket option an can be enabled or disabled for a socket via `setsockopt`. If enabled, outgoing data are aggregated in a buffer until either a full size TCP frame can be sent or 200ms have elapsed or TCP Cork has been disabled for the socket. This means that the output buffer can be deliberately flushed by disabling and then re-enabling `TCP_CORK` for a socket. Reference: [`man 7 tcp`](http://man7.org/linux/man-pages/man7/tcp.7.html).

Control messages such as "Suspend" or "Stop" are small (tens of bytes) and therefore are likely held back by TCP Cork, but they need to be passed on as soon as possible. So a request handler needs a way of flushing the TCP Cork buffer: `RequestOnConnBase.EventDispatcher.flush()`, which calls `MessageSender.flush()`.
Of course this is useful only if `flush()` is called right after the socket `write` call -- *right after* meaning that no event loop cycle has been done or other request or I/O handler fibers have been active in the mean time. This is accomplished if the request handler calls `flush()` right after one of the `EventDispatcher.send*` methods has returned, which results in the following program flow:
`EventDispatcher.send*` either is or calls one of the `send(Receive)AndHandleEvents` methods, which calls `RequestOnConnBase.registerForSending`. Now there are two possibilities.
1. The send loop is idle.
    - `SendLoop.registerForSending` resumes the send fiber (from the request handler fiber).
    - `SendLoop.loop` calls `SendLoop.sendRequestPayload`, which calls `RequestOnConnBase.getPayloadForSending`.
    - `RequestOnConnBase.getPayloadForSending` calls the `send` callback, which eventually makes the socket `write` call, and returns. It notices that the request handler fiber is not suspended so it doesn't resume it and returns right away.
   - Depending on `finish_sending`
        - if `false`, `SendLoop.sendRequestPayload` returns and `SendLoop.loop` suspends the send fiber (since the send loop was idle and no other request handler fiber has been active the send queue is now empty);
        - if `true`, calling `MessageSender.finishSending` suspends the send fiber.
    Either way the send fiber is suspended and the request handler fiber continues.
    - `RequestOnConnBase.registerForSending` returns.
    -  `send(Receive)AndHandleEvents` sees that `outer.send_payload_ is null` and returns.
    - The request now calls `EventDispatcher.flush`, which is right after the socket `write` call has been made.
2. The send loop is busy.
    - `SendLoop.registerForSending` pushes the request id in the send queue and returns.
    - `send(Receive)AndHandleEvents` sees that `outer.send_payload_` is still there and suspends the request handler fiber.
    - At some point the send fiber is active, `SendLoop.loop` pops the request id from the send queue and calls `SendLoop.sendRequestPayload`, which calls `RequestOnConnBase.getPayloadForSending`.
    - `RequestOnConnBase.getPayloadForSending` calls the `send` callback, which eventually makes the socket `write` call, and returns. It notices that the request handler fiber is suspended so it resumes it.
    - `send(Receive)AndHandleEvents` returns.
    - The request now calls `EventDispatcher.flush`, which is right after the socket `write` call has been made.