### PR TITLE
GetAllTest: Fix race condition between node End and client control message

### DIFF
--- a/test/neo/client/request/internal/GetAll.d
+++ b/test/neo/client/request/internal/GetAll.d
@@ -399,6 +399,14 @@ private struct Reader
         }
         while ( !finished );
 
+        // Acknowledge the End signal. The protocol guarantees that the node
+        // will not send any further messages.
+        this.request_event_dispatcher.send(this.fiber,
+            ( RequestOnConn.EventDispatcher.Payload payload )
+            {
+                payload.addConstant(MessageType.Ack);
+            }
+        );
         // Kill the controller fiber.
         this.request_event_dispatcher.abort(this.controller.fiber);
     }

--- a/test/neo/main.d
+++ b/test/neo/main.d
@@ -226,7 +226,7 @@ class Test : Task
 
     /***************************************************************************
 
-        Runs a simple test where three records are written to the node with Put
+        Runs a simple test where records are written to the node with Put
         and then fetched with GetAll. As soon as the first record is received,
         the request is suspended. As soon as the suspension is ACKed by the
         node, the request is resumed.

--- a/test/neo/node/request/GetAll.d
+++ b/test/neo/node/request/GetAll.d
@@ -69,6 +69,10 @@ private scope class GetAllImpl_v0
     import swarm.neo.util.MessageFiber;
     import swarm.neo.request.RequestEventDispatcher;
 
+    /// Set by the Writer when the iteration over the records has finished. Used
+    /// by the Controller to ignore incoming messages from that point.
+    private bool has_ended;
+
     /// Fiber which handles iterating and sending records to the client.
     private class Writer
     {
@@ -100,6 +104,8 @@ private scope class GetAllImpl_v0
                 );
             }
 
+            this.outer.has_ended = true;
+
             // Send the End message to the client.
             this.outer.request_event_dispatcher.send(this.fiber,
                 ( RequestOnConn.EventDispatcher.Payload payload )
@@ -107,6 +113,9 @@ private scope class GetAllImpl_v0
                     payload.addConstant(MessageType.End);
                 }
             );
+
+            this.outer.request_event_dispatcher.receive(this.fiber,
+                Message(MessageType.Ack));
 
             // Kill the controller fiber.
             this.outer.request_event_dispatcher.abort(
@@ -133,6 +142,12 @@ private scope class GetAllImpl_v0
                 auto message = this.outer.request_event_dispatcher.receive(this.fiber,
                     Message(MessageType.Suspend), Message(MessageType.Resume),
                     Message(MessageType.Stop));
+
+                // If the request has ended, ignore incoming control messages.
+                // We may receive a control message which the client sent before
+                // it received or processed the End message we sent.
+                if (this.outer.has_ended)
+                    continue;
 
                 // Send ACK. The protocol guarantees that the client will not
                 // send any further messages until it has received the ACK.


### PR DESCRIPTION
After the node sent the End message to the client it may receive a control message which the client sent before it received or processed the `End` message. Handle this as follows: The client needs to `Ack`nowledge the `End` message. The node ends the request after receiving that `Ack` and ignores incoming control messages in the mean time.