### PR TITLE
Flush after sending where needed

### DIFF
--- a/src/swarm/neo/client/helper/SuspendableRequest.d
+++ b/src/swarm/neo/client/helper/SuspendableRequest.d
@@ -602,6 +602,7 @@ struct SuspendableRequest
                     payload.add(control_msg);
                 }
             );
+            this.conn.flush();
 
             if ( !send_interrupted ) // The control message was sent
                 break;

--- a/src/swarm/neo/client/mixins/SuspendableRequestCore.d
+++ b/src/swarm/neo/client/mixins/SuspendableRequestCore.d
@@ -812,6 +812,7 @@ public struct SuspendableRequestControllerFiber ( Request, MessageType )
                 payload.add(msg);
             }
         );
+        this.conn.flush();
 
         // Wait for ACK.
         this.request_event_dispatcher.receive(this.fiber,

--- a/src/swarm/neo/node/helper/SuspendableRequest.d
+++ b/src/swarm/neo/node/helper/SuspendableRequest.d
@@ -176,6 +176,7 @@ public struct SuspendableRequest
                     payload.add(channel_removed_msg);
                 }
             );
+            this.conn.flush();
         }
         while ( send_interrupted );
     }
@@ -478,5 +479,6 @@ public struct SuspendableRequest
                 payload.add(ack);
             }
         );
+        this.conn.flush();
     }
 }

--- a/test/neo/client/request/internal/Get.d
+++ b/test/neo/client/request/internal/Get.d
@@ -136,6 +136,7 @@ public struct Get
                             payload.add(context.user_params.args.key);
                         }
                     );
+                    conn.flush();
 
                     // Receive status from node
                     auto status = conn.receiveValue!(StatusCode)();

--- a/test/neo/client/request/internal/GetAll.d
+++ b/test/neo/client/request/internal/GetAll.d
@@ -407,6 +407,8 @@ private struct Reader
                 payload.addConstant(MessageType.Ack);
             }
         );
+        this.conn.flush();
+
         // Kill the controller fiber.
         this.request_event_dispatcher.abort(this.controller.fiber);
     }

--- a/test/neo/client/request/internal/Put.d
+++ b/test/neo/client/request/internal/Put.d
@@ -136,6 +136,7 @@ public struct Put
                             payload.addArray(context.user_params.args.value);
                         }
                     );
+                    conn.flush();
 
                     // Receive status from node
                     auto status = conn.receiveValue!(StatusCode)();

--- a/test/neo/node/request/Get.d
+++ b/test/neo/node/request/Get.d
@@ -114,5 +114,6 @@ private scope class GetImpl_v0
                 }
             );
         }
+        ed.flush();
     }
 }

--- a/test/neo/node/request/GetAll.d
+++ b/test/neo/node/request/GetAll.d
@@ -113,6 +113,7 @@ private scope class GetAllImpl_v0
                     payload.addConstant(MessageType.End);
                 }
             );
+            this.outer.conn.flush();
 
             this.outer.request_event_dispatcher.receive(this.fiber,
                 Message(MessageType.Ack));
@@ -157,6 +158,7 @@ private scope class GetAllImpl_v0
                         payload.addConstant(MessageType.Ack);
                     }
                 );
+                this.outer.conn.flush();
 
                 // Carry out the specified control message.
                 with ( MessageType ) switch ( message.type )
@@ -224,6 +226,7 @@ private scope class GetAllImpl_v0
                 payload.addConstant(RequestStatusCode.Started);
             }
         );
+        this.conn.flush();
 
         // Now ready to start sending data from the storage and to handle
         // control messages from the client. Each of these jobs is handled by a

--- a/test/neo/node/request/Put.d
+++ b/test/neo/node/request/Put.d
@@ -97,5 +97,6 @@ private scope class PutImpl_v0
                 payload.addConstant(RequestStatusCode.Succeeded);
             }
         );
+        ed.flush();
     }
 }


### PR DESCRIPTION
- Flush after sending a control message because control messages need to be delivered with low latency. In swarm control messages are semt in suspendable requests. (Are there more places in swarm? I didn't find any.)
- In the neo test flush after sending a control or Get/Put message. The test does one Get/Put request at a time so without flushing it takes too long.