### PR TITLE
Don't use deprecated Formatter.sformat overload if the replacement is…

### DIFF
--- a/src/swarm/neo/client/NotifierTypes.d
+++ b/src/swarm/neo/client/NotifierTypes.d
@@ -18,7 +18,7 @@ module swarm.neo.client.NotifierTypes;
 *******************************************************************************/
 
 import ocean.transition;
-import Formatter = ocean.text.convert.Formatter;
+import swarm.neo.util.Formatter;
 
 /*******************************************************************************
 
@@ -44,12 +44,7 @@ public struct NodeInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+        sformat(sink,
             "Node {}:{}",
             this.node_addr.address_bytes, this.node_addr.port);
     }
@@ -83,12 +78,8 @@ public struct RequestNodeInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+        sformat(
+            sink,
             "Request #{}, node {}:{}",
             this.request_id, this.node_addr.address_bytes, this.node_addr.port);
     }
@@ -131,12 +122,8 @@ public struct RequestNodeUnsupportedInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+        sformat(
+            sink,
             "Request #{}, node {}:{} reported that the {} is not supported",
             this.request_id, this.node_addr.address_bytes, this.node_addr.port,
             this.type_explanation);
@@ -191,15 +178,9 @@ public struct NodeExceptionInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        size_t size_sink ( cstring chunk )
-        {
-            sink(chunk);
-            return chunk.length;
-        }
-
         if ( this.e !is null )
         {
-            Formatter.sformat(&size_sink,
+            sformat(sink,
                 "Exception '{}' @ {}:{} occurred in the client while handling the "
                 "request on node {}:{}",
                 getMsg(this.e), this.e.file, this.e.line,
@@ -207,7 +188,7 @@ public struct NodeExceptionInfo
         }
         else
         {
-            Formatter.sformat(&size_sink,
+            sformat(sink,
                 "An undefined error (null Exception) occurred in the client "
                 "while handling the request on node {}:{}",
                 this.node_addr.address_bytes, this.node_addr.port);
@@ -246,15 +227,9 @@ public struct RequestNodeExceptionInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        size_t size_sink ( cstring chunk )
-        {
-            sink(chunk);
-            return chunk.length;
-        }
-
         if ( this.e !is null )
         {
-            Formatter.sformat(&size_sink,
+            sformat(sink,
                 "Exception '{}' @ {}:{} occurred in the client while handling "
                 "request #{} on node {}:{}",
                 getMsg(this.e), this.e.file, this.e.line, this.request_id,
@@ -262,7 +237,7 @@ public struct RequestNodeExceptionInfo
         }
         else
         {
-            Formatter.sformat(&size_sink,
+            sformat(sink,
                 "An undefined error (null Exception) occurred in the client "
                 "while handling request #{} on node {}:{}",
                 this.request_id, this.node_addr.address_bytes,
@@ -298,12 +273,7 @@ public struct RequestDataInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+        sformat(sink,
             "Request #{} provided the value {}",
             this.request_id, this.value);
     }
@@ -356,12 +326,7 @@ public struct RequestInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+        sformat(sink,
             "Request #{}",
             this.request_id);
     }

--- a/src/swarm/neo/client/requests/NotificationFormatter.d
+++ b/src/swarm/neo/client/requests/NotificationFormatter.d
@@ -15,7 +15,7 @@ module swarm.neo.client.requests.NotificationFormatter;
 import ocean.transition;
 import ocean.core.SmartUnion;
 import ocean.core.Traits : TemplateInstanceArgs, hasMethod;
-import Formatter = ocean.text.convert.Formatter;
+import swarm.neo.util.Formatter;
 
 import swarm.neo.client.NotifierTypes;
 
@@ -70,13 +70,7 @@ public void formatNotification ( SU ) ( SU notification, Sink sink )
 {
     static assert(is(TemplateInstanceArgs!(SmartUnion, SU)));
 
-    Formatter.sformat(
-        ( cstring chunk )
-        {
-            sink(chunk);
-            return chunk.length;
-        },
-        "<{}>", notification.active_name
+        sformat(sink, "<{}>", notification.active_name
     );
 
     .format_sink = sink;

--- a/src/swarm/neo/util/Formatter.d
+++ b/src/swarm/neo/util/Formatter.d
@@ -1,0 +1,77 @@
+/*******************************************************************************
+
+    Wrapper around Ocean's ocean.text.convert.Formatter.sformat used to
+    avoid usage of the deprecated overload that accepts a sink returning
+    size_t in case overload accepting sink returning void is present (since
+    ocean v2.8.
+
+    This module could be removed and all code reverted to simply use
+    ocean's Formatter in the next major.
+
+    Copyright: Copyright (c) 2016-2017 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+
+*******************************************************************************/
+
+module swarm.neo.util.Formatter;
+
+import ocean.transition;
+import ocean.core.VersionCheck;
+import Formatter = ocean.text.convert.Formatter;
+
+static if (hasFeaturesFrom!("ocean", 2, 8))
+{
+    /***************************************************************************
+
+        Send the processed (formatted) input into a sink
+
+        Params:
+            sink    = A delegate that will be called, possibly multiple
+                        times, with a portion of the result string
+            fmt     = Format string to use
+            args    = Variadic arguments to format according to fmt
+
+        Returns:
+            If formatting was successful, returns `true`, `false` otherwise.
+
+    ***************************************************************************/
+
+    public bool sformat (Args...) (
+            void delegate ( cstring chunk) sink,
+            cstring fmt, Args args )
+    {
+        return Formatter.sformat(sink, fmt, args);
+    }
+}
+else
+{
+    /***************************************************************************
+
+        Send the processed (formatted) input into a sink
+
+        Params:
+            sink    = A delegate that will be called, possibly multiple
+                        times, with a portion of the result string
+            fmt     = Format string to use
+            args    = Variadic arguments to format according to fmt
+
+        Returns:
+            If formatting was successful, returns `true`, `false` otherwise.
+
+    ***************************************************************************/
+
+    public bool sformat (Args...) (
+            void delegate ( cstring chunk) sink,
+            cstring fmt, Args args )
+    {
+        return Formatter.sformat(
+            ( cstring chunk )
+            {
+                sink(chunk);
+                return chunk.length;
+            },
+            fmt, args);
+    }
+}

--- a/test/neo/client/NotifierTypes.d
+++ b/test/neo/client/NotifierTypes.d
@@ -15,6 +15,7 @@
 module test.neo.client.NotifierTypes;
 
 public import swarm.neo.client.NotifierTypes;
+import swarm.neo.util.Formatter;
 
 /*******************************************************************************
 
@@ -47,12 +48,7 @@ public struct RequestKeyDataInfo
 
     public void toString ( void delegate ( cstring chunk ) sink )
     {
-        Formatter.sformat(
-            ( cstring chunk )
-            {
-                sink(chunk);
-                return chunk.length;
-            },
+            sformat(sink,
             "Request #{} provided the key {} and the value {}",
             this.request_id, this.key, this.value);
     }


### PR DESCRIPTION
… present

Ocean v2.8.x+ deprecates sformat's overload that accepts a sink
returning size_t in favour of the one returning void. In order to
suppress deprecation messages, swarm wraps the sformat and chooses the
right overload based on the ocean's version check.