### PR TITLE
Retry AllNodesRequest on EpollException, not just on IOError

### DIFF
--- a/src/swarm/neo/client/mixins/AllNodesRequestCore.d
+++ b/src/swarm/neo/client/mixins/AllNodesRequestCore.d
@@ -96,7 +96,7 @@ public struct AllNodesRequest ( Request, Connector, Disconnected, Initialiser,
     Handler )
 {
     import swarm.neo.client.RequestOnConn;
-    import ocean.io.select.protocol.generic.ErrnoIOException : IOError;
+    import ocean.io.select.selector.EpollException;
 
     /// Policy object for handling connection establishment.
     private Connector connector;
@@ -142,7 +142,7 @@ public struct AllNodesRequest ( Request, Connector, Disconnected, Initialiser,
             }
             // Only retry in the case of a connection error. Other errors
             // indicate internal problems and should not be retried.
-            catch ( IOError e )
+            catch ( EpollException e )
             {
                 this.disconnected(e);
                 reconnect = true;


### PR DESCRIPTION
IOError are representing just a subset of the read/write issues that
can happen on the connection. For example, hangup of the remote party
will result in the IOWarning, or being unable to send any packet to the
remote party will result in (more general) EpollException. In all these
reasons, where the disconnection occurs, request should try to reconnect
to the node and continue request, not just on IOErrors.