### PR TITLE
Deprecate swarm.neo.*.helper.SuspendableRequest

### DIFF
--- a/relnotes/suspendable-request.deprecation.md
+++ b/relnotes/suspendable-request.deprecation.md
@@ -1,0 +1,8 @@
+* `swarm.neo.node.helper.SuspendableRequest`,
+  `swarm.neo.client.helper.SuspendableRequest`
+
+  The old, side suspendable request helpers are now out-moded. Requests based
+  on these structs should be reimplemented to work with multiple fibers and use
+  the `RequestEventDispatcher`. See `test.neo.client.request.internal.GetAll`
+  and `test.neo.node.request.GetAll` for example.
+

--- a/src/swarm/neo/client/helper/SuspendableRequest.d
+++ b/src/swarm/neo/client/helper/SuspendableRequest.d
@@ -37,9 +37,11 @@
 
 *******************************************************************************/
 
-module swarm.neo.client.helper.SuspendableRequest;
+deprecated module swarm.neo.client.helper.SuspendableRequest;
 
 /// ditto
+deprecated("Adapt your request to use RequestEventDispatcher and multiple fibers "
+    "instead. See swarm.neo.client.mixins.SuspendableRequestCore")
 struct SuspendableRequest
 {
     import ocean.transition;

--- a/src/swarm/neo/node/helper/SuspendableRequest.d
+++ b/src/swarm/neo/node/helper/SuspendableRequest.d
@@ -22,9 +22,11 @@
 
 *******************************************************************************/
 
-module swarm.neo.node.helper.SuspendableRequest;
+deprecated module swarm.neo.node.helper.SuspendableRequest;
 
 /// ditto
+deprecated("Adapt your request to use RequestEventDispatcher and multiple fibers "
+    "instead")
 public struct SuspendableRequest
 {
     import ocean.transition;


### PR DESCRIPTION
It has been superseded by RequestEventDispatcher.