### PR TITLE
Enable TCP_KEEPALIVE after the connection with the remote party

### DIFF
--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -499,6 +499,7 @@ public final class Connection: ConnectionBase
                 this.client_socket, this.node_address, this.send_loop,
                 this.epoll, this.receiver, this.sender, this.protocol_error
             );
+            enableKeepAlive(this.client_socket.socket);
 
             debug ( SwarmConn )
                 Stdout.formatln("{}:{}: Connection.tryConnect() succeeded",

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -682,7 +682,6 @@ abstract class ConnectionBase: ISelectClient
     protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll )
     {
         this.socket               = socket;
-        this.enableKeepAlive();
         this.epoll                = epoll;
         this.protocol_error_      = new ProtocolError;
         this.parser.e             = this.protocol_error_;
@@ -964,28 +963,31 @@ abstract class ConnectionBase: ISelectClient
 
         Sets up TCP keep-alive on the initialised socket.
 
+        Params:
+            socket = socket to enable TCP keep-alive on. It must be connected
+
     ***************************************************************************/
 
-    protected void enableKeepAlive ( )
+    protected static void enableKeepAlive ( AddressIPSocket!() socket )
     in
     {
-        assert(this.socket !is null);
+        assert(socket !is null);
     }
     body
     {
         // Activates TCP's keepalive feature for this socket.
-        this.socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
+        socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
 
         // Socket idle time in seconds after which TCP will start sending
         // keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
 
         // Maximum number of keepalive probes before the connection is declared
         // dead and dropped.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
 
         // Time in seconds between keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
     }
 
     /***************************************************************************

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -40,6 +40,7 @@ abstract class ConnectionBase: ISelectClient
     import ocean.io.select.EpollSelectDispatcher;
     import ocean.io.select.protocol.generic.ErrnoIOException;
 
+    import ocean.sys.ErrnoException;
     import ocean.sys.socket.AddressIPSocket;
 
     import swarm.neo.util.TreeMap;
@@ -976,18 +977,30 @@ abstract class ConnectionBase: ISelectClient
     body
     {
         // Activates TCP's keepalive feature for this socket.
-        socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
+        if (socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set SO_KEEPALIVE");
+        }
 
         // Socket idle time in seconds after which TCP will start sending
         // keepalive probes.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPIDLE");
+        }
 
         // Maximum number of keepalive probes before the connection is declared
         // dead and dropped.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPCNT");
+        }
 
         // Time in seconds between keepalive probes.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPINTVL");
+        }
     }
 
     /***************************************************************************

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -200,6 +200,8 @@ class Connection: ConnectionBase
             this.socket.setsockoptVal(IPPROTO_TCP,
                 socket.TcpOptions.TCP_NODELAY, true);
 
+        this.enableKeepAlive(this.socket);
+
         // If authentication fails the connection is simply disconnected and
         // returned to the pool.
 


### PR DESCRIPTION
TCP_KEEPALIVE socket option should be set on the TCP connectionrepresented by socket, not on the socket that doesn't back anyconnection. This enables it only after the connection has been made, notin the constructor which doesn't need to have the connected socket.

Port of #73 to v3.3.x branch.
