### PR TITLE
Allow for properly disabling socket output buffering

### DIFF
--- a/relnotes/client-nodelay.feature.md
+++ b/relnotes/client-nodelay.feature.md
@@ -1,0 +1,5 @@
+* `swarm.neo.client.mixins.ClientCore`
+
+  The new `enableSocketNoDelay` method can be used to disable socket output
+  buffering in tests.
+

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -218,15 +218,20 @@ public final class Connection: ConnectionBase
             credentials  = authentication credentials
             request_set  = the request set
             epoll        = epoll select dispatcher
+            no_delay     = if false, data written to the socket will be buffered
+                and sent according to Nagle's algorithm and TCP Cork. If true,
+                no buffering will occur. (The no-delay option is not generally
+                suited to live servers, where efficient packing of packets is
+                desired, but can be useful for low-bandwidth test setups.)
 
     ***************************************************************************/
 
     public this ( Const!(Credentials) credentials, IRequestSet request_set,
-                  EpollSelectDispatcher epoll )
+                  EpollSelectDispatcher epoll, bool no_delay = false )
     {
         this.client_socket = new ClientSocket;
 
-        super(this.client_socket.socket, epoll);
+        super(this.client_socket.socket, epoll, no_delay);
 
         this.conn_init = new ClientConnect(credentials);
         this.request_set = request_set;

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -43,6 +43,18 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
 
     /***************************************************************************
 
+        Set this flag to `true` before calling `start` to prevent TCP socket
+        output data buffering through Nagle's algorithm and TCP Cork.
+        Warning: This is meant to be used only in tests which perform sequential
+        requests. For a high data throughput rate it may impact performance so
+        do not use it in a production environment.
+
+    ***************************************************************************/
+
+    public bool socket_no_delay = false;
+
+    /***************************************************************************
+
         Registry of connections.
 
     ***************************************************************************/
@@ -230,7 +242,8 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
         bool added;
         auto connection = this.connections.put(node_address, added,
             this.connection_pool.get(new Connection(
-                this.credentials, this.request_set_, this.epoll
+                this.credentials, this.request_set_, this.epoll,
+                this.socket_no_delay
             ))
         );
 

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -605,6 +605,22 @@ template ClientCore ( )
             static assert(false, "Invalid request type");
         }
     }
+
+    /***************************************************************************
+
+        Disables TCP socket output data buffering. Should be called before
+        adding a node.
+
+        Warning: This is meant to be used only in tests which perform sequential
+        requests. For a high data throughput rate it may impact performance so
+        do not use it in a production environment.
+
+    ***************************************************************************/
+
+    public void enableSocketNoDelay ( )
+    {
+        this.connections.socket_no_delay = true;
+    }
 }
 
 /*******************************************************************************

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -263,7 +263,11 @@ abstract class ConnectionBase: ISelectClient
 
                 try
                 {
-                    this.outer.sender.cork = true;
+                    if (this.outer.no_delay)
+                        this.outer.socket.setsockoptVal(IPPROTO_TCP,
+                            socket.TcpOptions.TCP_NODELAY, true);
+                    else
+                        this.outer.sender.cork = true;
 
                     // Start the receive fiber, it will suspend itself immediately.
                     this.outer.recv_loop.start();
@@ -669,6 +673,34 @@ abstract class ConnectionBase: ISelectClient
 
     /***************************************************************************
 
+        Flag controlling which TCP/IP `setsockopt(2)` socket options controlling
+        delayed sending of outgoing data should be used to accomplish either a
+        low delay or reduce the number of network data packets sent.
+
+        - `false` enables output buffering via `TCP_CORK` and leaves
+          `TCP_NODELAY` disabled. This aims to reduce the number of network data
+          packets sent but adds a delay if the output data rate is low. Note
+          that the delay does not reduce the data throughput rate if I/O
+          pipelining is used properly: Tests have shown that it can dramatically
+          increase the data throughput and the performance of both the server
+          and the client.
+
+        - `true` leaves output buffering via `TCP_CORK` disabled and enables
+          `TCP_NODELAY` (i.e. disable Nagle's algorithm). This is typically
+          necessary for tests where a client sends a sequence of requests,
+          waiting until the current request has finished before sending the
+          next. Because this method does not use I/O pipelining, it is suitable
+          only for tests, not for production where high data throughput is
+          desired. Tests have shown that in a production environment disabling
+          output buffering can dramatically decrease the data throughput and the
+          performance of both the server and the client.
+
+    ***************************************************************************/
+
+    protected Immut!(bool) no_delay;
+
+    /***************************************************************************
+
         Constructor.
 
         At this point the socket does not have to contain a valid file
@@ -677,13 +709,17 @@ abstract class ConnectionBase: ISelectClient
         Params:
             socket       = node/client connection socket
             epoll        = epoll select dispatcher for registering the socket
+            no_delay     = disables TCP socket output buffering (see comments on
+                           the no_delay field, above)
 
     ***************************************************************************/
 
-    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll )
+    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll,
+        bool no_delay = false )
     {
         this.socket               = socket;
         this.epoll                = epoll;
+        this.no_delay             = no_delay;
         this.protocol_error_      = new ProtocolError;
         this.parser.e             = this.protocol_error_;
         this.receiver             = new MessageReceiver(this.socket, this.protocol_error_);


### PR DESCRIPTION
The recently added socket output buffering via `TCP_CORK` slows application tests down. So far a node can enable `TCP_NODELAY` by passing `no_delay = true` to the `Connection` constructor, but that is not enough: Both node and client need to enable `TCP_NODELAY` and disable `TCP_CORK`.
This PR adds a `bool no_delay` parameter to the client `Connection` constructor, extends its meaning to disable `TCP_CORK` in addition, and adds a `enableSocketNoDelay()` method to swarm neo clients.

To keep the code simpler `TCP_NODELAY` is now enabled after the authentication has completed, it used to be enabled from the beginning in the node. It should not make a difference because during handshake and authentication both client and node each wait for a response before sending the next message, which is precisely what Nagle's algorithm tries to accomplish.