### PR TITLE
Neo socket output buffering + TCP Keepalive for v4.0.x

### DIFF
--- a/relnotes/client-nodelay.feature.md
+++ b/relnotes/client-nodelay.feature.md
@@ -1,0 +1,5 @@
+* `swarm.neo.client.mixins.ClientCore`
+
+  The new `enableSocketNoDelay` method can be used to disable socket output
+  buffering in tests.
+

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -501,6 +501,7 @@ public final class Connection: ConnectionBase
                 this.client_socket, this.node_address, this.send_loop,
                 this.epoll, this.receiver, this.sender, this.protocol_error
             );
+            enableKeepAlive(this.client_socket.socket);
 
             debug ( SwarmConn )
                 Stdout.formatln("{}:{}: Connection.tryConnect() succeeded",

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -219,15 +219,20 @@ public final class Connection: ConnectionBase
             credentials  = authentication credentials
             request_set  = the request set
             epoll        = epoll select dispatcher
+            no_delay     = if false, data written to the socket will be buffered
+                and sent according to Nagle's algorithm and TCP Cork. If true,
+                no buffering will occur. (The no-delay option is not generally
+                suited to live servers, where efficient packing of packets is
+                desired, but can be useful for low-bandwidth test setups.)
 
     ***************************************************************************/
 
     public this ( Const!(Credentials) credentials, IRequestSet request_set,
-                  EpollSelectDispatcher epoll )
+                  EpollSelectDispatcher epoll, bool no_delay = false )
     {
         this.client_socket = new ClientSocket;
 
-        super(this.client_socket.socket, epoll);
+        super(this.client_socket.socket, epoll, no_delay);
 
         this.conn_init = new ClientConnect(credentials);
         this.request_set = request_set;

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -45,6 +45,18 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
 
     /***************************************************************************
 
+        Set this flag to `true` before calling `start` to prevent TCP socket
+        output data buffering through Nagle's algorithm and TCP Cork.
+        Warning: This is meant to be used only in tests which perform sequential
+        requests. For a high data throughput rate it may impact performance so
+        do not use it in a production environment.
+
+    ***************************************************************************/
+
+    public bool socket_no_delay = false;
+
+    /***************************************************************************
+
         Registry of connections.
 
     ***************************************************************************/
@@ -252,7 +264,8 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
         bool added;
         auto connection = this.connections.put(node_address, added,
             this.connection_pool.get(new Connection(
-                this.credentials, this.request_set_, this.epoll
+                this.credentials, this.request_set_, this.epoll,
+                this.socket_no_delay
             ))
         );
 

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -613,6 +613,22 @@ template ClientCore ( )
             static assert(false, "Invalid request type");
         }
     }
+
+    /***************************************************************************
+
+        Disables TCP socket output data buffering. Should be called before
+        adding a node.
+
+        Warning: This is meant to be used only in tests which perform sequential
+        requests. For a high data throughput rate it may impact performance so
+        do not use it in a production environment.
+
+    ***************************************************************************/
+
+    public void enableSocketNoDelay ( )
+    {
+        this.connections.socket_no_delay = true;
+    }
 }
 
 /*******************************************************************************

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -40,6 +40,7 @@ abstract class ConnectionBase: ISelectClient
     import ocean.io.select.EpollSelectDispatcher;
     import ocean.io.select.protocol.generic.ErrnoIOException;
 
+    import ocean.sys.ErrnoException;
     import ocean.sys.socket.AddressIPSocket;
 
     import swarm.neo.util.TreeMap;
@@ -1018,18 +1019,30 @@ abstract class ConnectionBase: ISelectClient
     body
     {
         // Activates TCP's keepalive feature for this socket.
-        socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
+        if (socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set SO_KEEPALIVE");
+        }
 
         // Socket idle time in seconds after which TCP will start sending
         // keepalive probes.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPIDLE");
+        }
 
         // Maximum number of keepalive probes before the connection is declared
         // dead and dropped.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPCNT");
+        }
 
         // Time in seconds between keepalive probes.
-        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
+        if (socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3) == -1)
+        {
+            throw (new ErrnoException).useGlobalErrno("Unable to set TCP_KEEPINTVL");
+        }
     }
 
     /***************************************************************************

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -266,6 +266,8 @@ abstract class ConnectionBase: ISelectClient
 
                 try
                 {
+                    this.outer.sender.cork = true;
+
                     // Start the receive fiber, it will suspend itself immediately.
                     this.outer.recv_loop.start();
 

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -41,6 +41,7 @@ abstract class ConnectionBase: ISelectClient
     import ocean.io.select.protocol.generic.ErrnoIOException;
 
     import ocean.sys.socket.AddressIPSocket;
+    import core.sys.posix.netinet.in_: IPPROTO_TCP;
 
     import swarm.neo.util.TreeMap;
     import swarm.neo.protocol.socket.IOStats;
@@ -266,7 +267,11 @@ abstract class ConnectionBase: ISelectClient
 
                 try
                 {
-                    this.outer.sender.cork = true;
+                    if (this.outer.no_delay)
+                        this.outer.socket.setsockoptVal(IPPROTO_TCP,
+                            socket.TcpOptions.TCP_NODELAY, true);
+                    else
+                        this.outer.sender.cork = true;
 
                     // Start the receive fiber, it will suspend itself immediately.
                     this.outer.recv_loop.start();
@@ -672,6 +677,34 @@ abstract class ConnectionBase: ISelectClient
 
     /***************************************************************************
 
+        Flag controlling which TCP/IP `setsockopt(2)` socket options controlling
+        delayed sending of outgoing data should be used to accomplish either a
+        low delay or reduce the number of network data packets sent.
+
+        - `false` enables output buffering via `TCP_CORK` and leaves
+          `TCP_NODELAY` disabled. This aims to reduce the number of network data
+          packets sent but adds a delay if the output data rate is low. Note
+          that the delay does not reduce the data throughput rate if I/O
+          pipelining is used properly: Tests have shown that it can dramatically
+          increase the data throughput and the performance of both the server
+          and the client.
+
+        - `true` leaves output buffering via `TCP_CORK` disabled and enables
+          `TCP_NODELAY` (i.e. disable Nagle's algorithm). This is typically
+          necessary for tests where a client sends a sequence of requests,
+          waiting until the current request has finished before sending the
+          next. Because this method does not use I/O pipelining, it is suitable
+          only for tests, not for production where high data throughput is
+          desired. Tests have shown that in a production environment disabling
+          output buffering can dramatically decrease the data throughput and the
+          performance of both the server and the client.
+
+    ***************************************************************************/
+
+    protected Immut!(bool) no_delay;
+
+    /***************************************************************************
+
         Constructor.
 
         At this point the socket does not have to contain a valid file
@@ -680,13 +713,17 @@ abstract class ConnectionBase: ISelectClient
         Params:
             socket       = node/client connection socket
             epoll        = epoll select dispatcher for registering the socket
+            no_delay     = disables TCP socket output buffering (see comments on
+                           the no_delay field, above)
 
     ***************************************************************************/
 
-    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll )
+    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll,
+        bool no_delay = false )
     {
         this.socket               = socket;
         this.epoll                = epoll;
+        this.no_delay             = no_delay;
         this.protocol_error_      = new ProtocolError;
         this.parser.e             = this.protocol_error_;
         this.receiver             = new MessageReceiver(this.socket, this.protocol_error_);

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -723,7 +723,6 @@ abstract class ConnectionBase: ISelectClient
         bool no_delay = false )
     {
         this.socket               = socket;
-        this.enableKeepAlive();
         this.epoll                = epoll;
         this.no_delay             = no_delay;
         this.protocol_error_      = new ProtocolError;
@@ -1006,28 +1005,31 @@ abstract class ConnectionBase: ISelectClient
 
         Sets up TCP keep-alive on the initialised socket.
 
+        Params:
+            socket = socket to enable TCP keep-alive on. It must be connected
+
     ***************************************************************************/
 
-    protected void enableKeepAlive ( )
+    protected static void enableKeepAlive ( AddressIPSocket!() socket )
     in
     {
-        assert(this.socket !is null);
+        assert(socket !is null);
     }
     body
     {
         // Activates TCP's keepalive feature for this socket.
-        this.socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
+        socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
 
         // Socket idle time in seconds after which TCP will start sending
         // keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
 
         // Maximum number of keepalive probes before the connection is declared
         // dead and dropped.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
 
         // Time in seconds between keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
+        socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
     }
 
     /***************************************************************************

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -485,6 +485,19 @@ abstract class RequestOnConnBase
 
         /***********************************************************************
 
+            Requests to send outgoing data buffered by the OS for the socket
+            immediately. By default outgoing data are buffered to the maximum
+            payload of a TCP frame using the Linux TCP_CORK socket option.
+
+        ***********************************************************************/
+
+        public void flush ( )
+        {
+            this.outer.connection.flush();
+        }
+
+        /***********************************************************************
+
             Sends a message for this request to the node.
 
             Do not resume the fiber before this method has returned or thrown.

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -29,8 +29,6 @@ class Connection: ConnectionBase
     import ocean.io.select.EpollSelectDispatcher;
     import ocean.sys.socket.AddressIPSocket;
 
-    import core.sys.posix.netinet.in_: SOL_SOCKET, IPPROTO_TCP, SO_KEEPALIVE;
-
     import ocean.transition;
 
     debug (SwarmConn) import ocean.io.Stdout_tango;
@@ -183,20 +181,6 @@ class Connection: ConnectionBase
             return false;
 
         this.first_connect_attempt = false;
-
-        // Activates TCP's keepalive feature for this socket.
-        this.socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);
-
-        // Socket idle time in seconds after which TCP will start sending
-        // keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPIDLE, 5);
-
-        // Maximum number of keepalive probes before the connection is declared
-        // dead and dropped.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPCNT, 3);
-
-        // Time in seconds between keepalive probes.
-        this.socket.setsockoptVal(IPPROTO_TCP, socket.TcpOptions.TCP_KEEPINTVL, 3);
 
         // If authentication fails the connection is simply disconnected and
         // returned to the pool.

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -79,19 +79,6 @@ class Connection: ConnectionBase
 
     /***************************************************************************
 
-        Flag controlling whether Nagle's algorithm is disabled (true) or left
-        enabled (false) on the underlying socket.
-
-        (The no-delay option is not generally suited to live servers, where
-        efficient packing of packets is desired, but can be useful for
-        low-bandwidth test setups.)
-
-    ***************************************************************************/
-
-    private bool no_delay;
-
-    /***************************************************************************
-
         Constructor.
 
         Params:
@@ -106,10 +93,10 @@ class Connection: ConnectionBase
                            multiple instances of this class
             task_resumer = global resumer to resume yielded `RequestOnConn`s
             no_delay = if false, data written to the socket will be buffered and
-                sent according to Nagle's algorithm. If true, no buffering will
-                occur. (The no-delay option is not generally suited to live
-                servers, where efficient packing of packets is desired, but can
-                be useful for low-bandwidth test setups.)
+                sent according to Nagle's algorithm and TCP Cork. If true, no
+                buffering will occur. (The no-delay option is not generally
+                suited to live servers, where efficient packing of packets is
+                desired, but can be useful for low-bandwidth test setups.)
 
     ***************************************************************************/
 
@@ -119,11 +106,10 @@ class Connection: ConnectionBase
                   void delegate ( ) when_closed, RequestPool request_pool,
                   YieldedRequestOnConns task_resumer, bool no_delay = false )
     {
-        super(socket, epoll);
+        super(socket, epoll, no_delay);
         this.request_set = new RequestSet(this, request_pool, task_resumer, request_handler);
         this.conn_init = new NodeConnect(credentials);
         this.when_closed = when_closed;
-        this.no_delay = no_delay;
     }
 
     /***************************************************************************
@@ -197,10 +183,6 @@ class Connection: ConnectionBase
             return false;
 
         this.first_connect_attempt = false;
-
-        if ( this.no_delay )
-            this.socket.setsockoptVal(IPPROTO_TCP,
-                socket.TcpOptions.TCP_NODELAY, true);
 
         // Activates TCP's keepalive feature for this socket.
         this.socket.setsockoptVal(SOL_SOCKET, SO_KEEPALIVE, true);

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -182,6 +182,8 @@ class Connection: ConnectionBase
 
         this.first_connect_attempt = false;
 
+        this.enableKeepAlive(this.socket);
+
         // If authentication fails the connection is simply disconnected and
         // returned to the pool.
 


### PR DESCRIPTION
This is needed for a patch release of a project that still uses v4.0.3.