### PR TITLE
Call I/O wait to yield before every socket read() call

### DIFF
--- a/src/swarm/neo/protocol/socket/MessageReceiver.d
+++ b/src/swarm/neo/protocol/socket/MessageReceiver.d
@@ -90,23 +90,6 @@ private class MessageReceiverBase
 
     protected size_t buffer_content_end = 0;
 
-    /***************************************************************************
-
-        The maximum number of subsequent `read` calls without an I/O-wait call.
-
-    ***************************************************************************/
-
-    private const uint read_iowait_max = 10;
-
-    /***************************************************************************
-
-        Counts the maximum number of subsequent `read` calls without an I/O-wait
-        call.
-
-    ***************************************************************************/
-
-    private uint read_iowait_count;
-
     /**************************************************************************/
 
     invariant ( )
@@ -419,20 +402,10 @@ private class MessageReceiverBase
             if (this.buffer.length < bytes_requested)
                 this.buffer.length = bytes_requested;
 
-            auto event = Event.EPOLLIN;
-
-            if (++this.read_iowait_count >= this.read_iowait_max)
-            {
-                this.read_iowait_count = 0;
-                this.io_stats.num_iowait_calls++;
-                event = wait;
-            }
-
-            this.read(event);
+            this.read(wait);
 
             while (this.buffer_content_end < bytes_requested)
             {
-                this.read_iowait_count = 0;
                 this.io_stats.num_iowait_calls++;
                 this.read(wait);
             }


### PR DESCRIPTION
10th subsequent socket `read()` calls are still too many before yielding. Revert the previous commit and yield before every socket `read()` call.