### PR TITLE
Always import ocean.core.Tuple in RequestOptions

### DIFF
--- a/src/swarm/neo/client/request_options/RequestOptions.d
+++ b/src/swarm/neo/client/request_options/RequestOptions.d
@@ -17,6 +17,7 @@
 module swarm.neo.client.request_options.RequestOptions;
 
 import ocean.transition;
+import ocean.core.Tuple;
 
 /*******************************************************************************
 
@@ -181,11 +182,6 @@ template eraseFromArgs (TypeToErase, options ...)
     {
         alias Tuple!() eraseFromArgs;
     }
-}
-
-version (UnitTest)
-{
-    import ocean.core.Tuple;
 }
 
 unittest


### PR DESCRIPTION
RequestOptions.eraseFromArgs will use ocean's tuple if there are
no options passed. In non-unittest builds this is not imported, and
since it's behind static if, it wouldn't fail until there's a
nonunittest app that uses it.