### PR TITLE
Don't pass empty channel name sentinel to the user for getChannels

### DIFF
--- a/src/swarm/client/request/GetChannelsRequest.d
+++ b/src/swarm/client/request/GetChannelsRequest.d
@@ -82,15 +82,16 @@ public scope class GetChannelsRequestTemplate ( Base : IRequest, Resources,
     {
         auto output = this.params.io_item.get_node_value();
 
-        do
-        {
-            this.reader.readArray(*this.resources.channel_buffer);
+        this.reader.readArray(*this.resources.channel_buffer);
 
+        while ( this.resources.channel_buffer.length )
+        {
             output(this.params.context, this.resources.conn_pool_info.address,
                 this.resources.conn_pool_info.port,
                 *this.resources.channel_buffer);
+
+            this.reader.readArray(*this.resources.channel_buffer);
         }
-        while ( this.resources.channel_buffer.length );
     }
 }
 


### PR DESCRIPTION
In legacy GetChannels request, every node will send the list of the
channels, followed by the empty entry, which serves as a sentinel. This
shouldn't be passed to the user.