### PR TITLE
Make IoVecTracker GC friendly

### DIFF
--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -155,7 +155,7 @@ struct IoVecTracker
 
     invariant ( )
     {
-        assert(this.length || this.fields is null);
+        assert(this.length || this.fields.length == 0);
     }
 
     /***************************************************************************
@@ -192,7 +192,8 @@ struct IoVecTracker
         {
             if (n == this.length)
             {
-                this.fields = null;
+                this.fields.length = 0;
+                enableStomping(this.fields);
             }
             else
             {

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -60,6 +60,7 @@ struct IoVecMessage // MessageGenerator
     body
     {
         this.tracker.fields.length = 1 + static_fields.length + dynamic_fields.length;
+        enableStomping(this.tracker.fields);
 
         with (this.tracker.fields[0])
         {
@@ -208,6 +209,7 @@ struct IoVecTracker
                         field.iov_base += field.iov_len - d;
                         field.iov_len  = d;
                         this.fields = this.fields[i .. $];
+                        enableStomping(this.fields);
                         break;
                     }
                 }
@@ -265,6 +267,7 @@ struct IoVecTracker
             assert(start == this.length);
 
             this.fields = this.fields[0 .. 1];
+            enableStomping(this.fields);
             this.fields[0] = iovec_const(dst.ptr, this.length);
         }
         else if (dst)


### PR DESCRIPTION
Previously, array of IoVecTracker were reset to `null`, making it allocate every time it's constructed. Also, some `enableStompings` are put in places where the length is shrinking.