### PR TITLE
Replace import of ocean.core.Thread with core.thread

### DIFF
--- a/src/swarm/neo/util/MessageFiber.d
+++ b/src/swarm/neo/util/MessageFiber.d
@@ -20,13 +20,13 @@ module swarm.neo.util.MessageFiber;
 
 import ocean.transition;
 
-import ocean.core.Thread : Fiber;
-
 import ocean.core.Array: copy;
 
 import ocean.core.SmartUnion;
 
 import ocean.io.digest.Fnv1;
+
+import core.thread : Fiber;
 
 debug ( MessageFiber )
 {
@@ -405,7 +405,7 @@ public class OceanMessageFiber
                 cast(void*) Fiber.getThis()
             ).flush();
         }
-     
+
         if (this.fiber.state == this.fiber.State.TERM)
         {
             this.fiber.reset();


### PR DESCRIPTION
ocean.core.Thread will be deprecated in ocean v3.5.0, so updating ahead of time for the convenience of users.