### PR TITLE
Fix `RequestEventDispatcher.eventLoop` not exiting

### DIFF
--- a/src/swarm/neo/request/RequestEventDispatcher.d
+++ b/src/swarm/neo/request/RequestEventDispatcher.d
@@ -533,6 +533,8 @@ public struct RequestEventDispatcher
 
             if ( this.waitingWriters() )
                 writer = this.popWaitingWriter();
+            else if ( !this.waiting_fibers.length )
+                break;
 
             this.handleNextEvent(conn, writer);
         }


### PR DESCRIPTION
`dispatchQueuedSignals` can continue waiting fibers so the event loop could call `nextEvent` with no waiting fiber. Instead, if there is no waiting fiber left, the event loop should exit.