### PR TITLE
Fix resuming terminated fiber in all-nodes request

### DIFF
--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -640,6 +640,21 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
 
     /***************************************************************************
 
+        Checks if the fiber is in `HOLD` state so it can be resumed.
+
+        Returns:
+            true if the fiber is in `HOLD` state or false if it is in `EXEC` or
+            `TERM` state.
+
+    ***************************************************************************/
+
+    public bool can_be_resumed ( )
+    {
+        return this.fiber.state == fiber.state.HOLD;
+    }
+
+    /***************************************************************************
+
         Populates this instance with request parameters.
 
         Params:

--- a/src/swarm/neo/client/RequestSet.d
+++ b/src/swarm/neo/client/RequestSet.d
@@ -470,7 +470,7 @@ public final class RequestSet: IRequestSet
             {
                 foreach ( request_on_conn; this.request_on_conns.all_nodes )
                 {
-                    if ( !request_on_conn.is_running )
+                    if ( request_on_conn.can_be_resumed )
                         request_on_conn.resumeFiber(resume_code);
                 }
             }


### PR DESCRIPTION
In the client `Request.resumeSuspendedHandlers` can attempt to resume a request handler fiber of an all-nodes request that has terminated already, causing an assertion to fail. Fix this by resuming only fibers that are in `HOLD` state rather than those that are not in `EXEC` state.