### PR TITLE
Fix usage of formatter in ProtocolError

### DIFF
--- a/src/swarm/neo/protocol/ProtocolError.d
+++ b/src/swarm/neo/protocol/ProtocolError.d
@@ -29,9 +29,6 @@ class ProtocolError: Exception
     import ocean.transition;
     import ocean.text.convert.Formatter;
 
-    static if (!is(FormatterSink))
-        alias Sink FormatterSink;
-
     /***************************************************************************
 
         Sets exception information for this instance.
@@ -96,17 +93,22 @@ class ProtocolError: Exception
     private void setFmt_ ( T... ) ( istring file, long line, cstring fmt, T args )
     {
         this.reused_msg.reset();
-        sformat(
-            cast(FormatterSink) (cstring chunk) {
-                this.reused_msg ~= chunk;
-                return chunk.length;
-            },
-            fmt,
-            args
-        );
+        // TODO: Remove the second branch (`else`) as it's meant to support
+        // the deprecated overload of ocean < v3.3.0
+        static if (is(FormatterSink))
+            sformat((cstring chunk) { this.reused_msg ~= chunk; }, fmt, args);
+        else
+            sformat(
+                (cstring chunk)
+                {
+                    this.reused_msg ~= chunk;
+                    return chunk.length;
+                },
+                fmt,
+                args
+            );
 
         this.file = file;
         this.line = line;
     }
 }
-


### PR DESCRIPTION
The code assumed that casting a delegate was safe and that the compiler would forgive you for returning a value from a void-returning delegate.
But it didn't.