### PR TITLE
Test with upstream v2.077.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
         - DMD=2.070.2.s* DIST=xenial F=devel
         - DMD=2.071.2.s* DIST=xenial F=production
         - DMD=2.071.2.s* DIST=xenial F=devel
+        - DMD=2.077.* DIST=xenial F=production
+        - DMD=2.077.* DIST=xenial F=devel
 
 install: beaver dlang install
 


### PR DESCRIPTION
Ocean v4.x.x, already test with v2.077.*, so any breakage of this build would be a result of swarm's change.