### PR TITLE
Flush all-nodes request initial payload

### DIFF
--- a/src/swarm/neo/client/mixins/AllNodesRequestCore.d
+++ b/src/swarm/neo/client/mixins/AllNodesRequestCore.d
@@ -404,6 +404,7 @@ public struct AllNodesRequestInitialiser ( Request, FillPayload,
                 this.fill_payload(payload);
             }
         );
+        this.conn.flush();
 
         // Receive status from node and stop the request if not Ok
         auto status = conn.receiveValue!(ubyte)();


### PR DESCRIPTION
Most all-nodes requests are long lived, so this isn't super important. Probably the right thing, though.