### PR TITLE
Make the enum generated via genMachineState public

### DIFF
--- a/src/swarm/neo/util/StateMachine.d
+++ b/src/swarm/neo/util/StateMachine.d
@@ -121,7 +121,7 @@ unittest
 unittest
 {
     test!("==")(genStateMachine(["One", "Two", "Three"]),
-        "private enum State:uint {Exit,One,Two,Three}" ~
+        "public enum State:uint {Exit,One,Two,Three}" ~
         "private State state;" ~
         "public void run ( State init_state ) {" ~
             "this.state = init_state; do {" ~
@@ -193,7 +193,7 @@ private istring genEnum ( istring[] states )
     assert(states.length);
 
     istring ret;
-    ret ~= "private enum State:uint {Exit";
+    ret ~= "public enum State:uint {Exit";
     foreach ( s; states )
     {
         ret ~= "," ~ s;
@@ -206,7 +206,7 @@ private istring genEnum ( istring[] states )
 unittest
 {
     test!("==")(genEnum(["One", "Two", "Three"]),
-        "private enum State:uint {Exit,One,Two,Three}");
+        "public enum State:uint {Exit,One,Two,Three}");
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Before it was private, however it also exposed a public function which used it as an argument,
which led to a weird situation where it couldn't be named.
The old protection rules did not catch this, but with the new visibility rules from v2.071+,
it creates a deprecation with dmqproto, which uses it in the fakedmq derived class.