### PR TITLE
Add RequestStarted to GlobalStatusCode enum

### DIFF
--- a/integrationtest/neo/common/GetAll.d
+++ b/integrationtest/neo/common/GetAll.d
@@ -45,7 +45,9 @@ public enum MessageType : ubyte
     Suspend, // Sent from the client to inform the node to suspend the iteration
     Resume,  // Sent from the client to inform the node to resume the iteration
     Stop,    // Sent from the client to inform the node to stop iterating
-    Ack      // Sent from the node to let the client know that a control message
+    Ack,     // Sent from the node to let the client know that a control message
              // (e.g. Stop) has been carried out
+    Error    // Sent from the node to let the client know that the error happened
+             // during serving the request.
 }
 

--- a/integrationtest/neo/node/request/Get.d
+++ b/integrationtest/neo/node/request/Get.d
@@ -50,7 +50,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
             ed.send(
                 ( ed.Payload payload )
                 {
-                    payload.addConstant(GlobalStatusCode.RequestVersionNotSupported);
+                    payload.addConstant(SupportedStatus.RequestVersionNotSupported);
                 }
             );
             break;

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -50,7 +50,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
             ed.send(
                 ( ed.Payload payload )
                 {
-                    payload.addConstant(GlobalStatusCode.RequestVersionNotSupported);
+                    payload.addConstant(SupportedStatus.RequestVersionNotSupported);
                 }
             );
             break;

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -62,6 +62,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
                     payload.addConstant(SupportedStatus.RequestVersionNotSupported);
                 }
             );
+            ed.flush();
             break;
     }
 }

--- a/integrationtest/neo/node/request/Put.d
+++ b/integrationtest/neo/node/request/Put.d
@@ -50,7 +50,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
             ed.send(
                 ( ed.Payload payload )
                 {
-                    payload.addConstant(GlobalStatusCode.RequestVersionNotSupported);
+                    payload.addConstant(SupportedStatus.RequestVersionNotSupported);
                 }
             );
             break;

--- a/relnotes/globalstatuscode.deprecation.md
+++ b/relnotes/globalstatuscode.deprecation.md
@@ -1,0 +1,11 @@
+## `GlobalStatusCode` enum is deprecated
+
+`swarm.neo.request.Command`
+
+Previously, the request supported/started handshake included request specific
+steps, so the request would extend the `GlobalStatusCode` enum with the request
+specific codes. This is going to be deprecated in favour of the request start
+handshake only checking if the request/version is supported, leaving the
+request specific codes out of swarm. As a result, the `GlobalStatusCode` enum
+is deprecated and in the existing requests it should be renamed to
+`SupportedStatus` which is backwards-compatible with it.

--- a/relnotes/handlesupport.feature.md
+++ b/relnotes/handlesupport.feature.md
@@ -1,0 +1,12 @@
+## `RequestCore.handleSupportedCodes` should be used to check for request support
+
+`swarm.neo.request.Command`
+
+Previously, the request supported/started handshake included request specific
+steps, so the request would extend the `GlobalStatusCode` enum with the request
+specific codes. This should no longer be used, but the request-specific errors
+should be left to the request implementation to specify/handle (possibly at any
+point during the request's lifetime). Swarm should be used just to check if the
+request (and the request's version) are supported, and this is where
+`handleSupportedCodes`, which checks if the node responded with the request
+(not) supported code, should be used.

--- a/src/swarm/neo/client/mixins/RequestCore.d
+++ b/src/swarm/neo/client/mixins/RequestCore.d
@@ -349,7 +349,7 @@ public template RequestCore ( RequestType request_type_, ubyte request_code,
     {
         switch ( status )
         {
-            case GlobalStatusCode.RequestNotSupported:
+            case SupportedStatus.RequestNotSupported:
                 NotificationUnion n;
                 n.unsupported = RequestNodeUnsupportedInfo();
                 n.unsupported.request_id = context.request_id;
@@ -359,7 +359,7 @@ public template RequestCore ( RequestType request_type_, ubyte request_code,
                 notify(context.user_params, n);
                 return true;
 
-            case GlobalStatusCode.RequestVersionNotSupported:
+            case SupportedStatus.RequestVersionNotSupported:
                 NotificationUnion n;
                 n.unsupported = RequestNodeUnsupportedInfo();
                 n.unsupported.request_id = context.request_id;

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -503,7 +503,7 @@ class ConnectionHandler : IConnectionHandler
         ed.send(
             ( ed.Payload payload )
             {
-                auto code = GlobalStatusCode.RequestNotSupported;
+                auto code = SupportedStatus.RequestNotSupported;
                 payload.add(code);
             }
         );

--- a/src/swarm/neo/request/Command.d
+++ b/src/swarm/neo/request/Command.d
@@ -61,6 +61,11 @@ public alias byte StatusCode;
 
 public enum GlobalStatusCode : StatusCode
 {
+    /// Both request code specified in the transmitted Command struct and the
+    /// associated request version are supported and the request will start
+    /// on this connection.
+    RequestSupported = -3,
+
     /// The request code specified in the transmitted Command struct is
     /// supported, but the associated request version is not.
     RequestVersionNotSupported = -2,

--- a/src/swarm/neo/request/Command.d
+++ b/src/swarm/neo/request/Command.d
@@ -59,7 +59,17 @@ public alias byte StatusCode;
 
 *******************************************************************************/
 
-public enum GlobalStatusCode : StatusCode
+deprecated ("Use the SupportedStatus instead of GlobalStatusCode")
+public alias SupportedStatus GlobalStatusCode;
+
+/*******************************************************************************
+
+    Enum defining request supported status codes transmitted from the node ->
+    client, in response to a request.
+
+*******************************************************************************/
+
+public enum SupportedStatus : StatusCode
 {
     /// Both request code specified in the transmitted Command struct and the
     /// associated request version are supported and the request will start


### PR DESCRIPTION
This PR adds support for moving the initial "request supported" handshake into the swarm. The request should be adapted so they don't send the request implementation defined `Started` code, but to just send `RequestStarted` when they are ready to start handling the request. Then they can send `Error` message (which is request defined) any time to the client, which should also expect it and abort everything with the `node_error`.

This is to allow request handlers to be `nothrow`, notifying the client about the error that just happened, and which can happen any time.

Node's connection handler then can be enhanced with the nothrow enforcement, but that needs to be done in the next major.