### PR TITLE
Rename test/* into integrationtest/*

### DIFF
--- a/integrationtest/client_auth/main.d
+++ b/integrationtest/client_auth/main.d
@@ -10,9 +10,9 @@
 
 *******************************************************************************/
 
-module test.client_auth.main;
+module integrationtest.client_auth.main;
 
-import test.neo.client.Client;
+import integrationtest.neo.client.Client;
 
 import swarm.neo.authentication.CredentialsFile;
 
@@ -24,7 +24,8 @@ import ocean.io.select.EpollSelectDispatcher;
 import Config = ocean.util.config.ConfigFiller;
 import ocean.util.config.ConfigParser;
 
-void main ( )
+version (UnitTest) {}
+else void main ( )
 {
     // Create temporary sandbox directory to write files to.
     auto sandbox = DirectorySandbox.create();

--- a/integrationtest/neo/client/Client.d
+++ b/integrationtest/neo/client/Client.d
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.Client;
+module integrationtest.neo.client.Client;
 
 import ocean.transition;
 
@@ -42,9 +42,9 @@ public class Client
 
         ***********************************************************************/
 
-        public import Get = test.neo.client.request.Get;
-        public import GetAll = test.neo.client.request.GetAll;
-        public import Put = test.neo.client.request.Put;
+        public import Get = integrationtest.neo.client.request.Get;
+        public import GetAll = integrationtest.neo.client.request.GetAll;
+        public import Put = integrationtest.neo.client.request.Put;
 
         /***********************************************************************
 
@@ -54,9 +54,9 @@ public class Client
 
         struct Internals
         {
-            import test.neo.client.request.internal.GetAll;
-            import test.neo.client.request.internal.Get;
-            import test.neo.client.request.internal.Put;
+            import integrationtest.neo.client.request.internal.GetAll;
+            import integrationtest.neo.client.request.internal.Get;
+            import integrationtest.neo.client.request.internal.Put;
         }
 
         /// Instantiation of ClientCore.

--- a/integrationtest/neo/client/NotifierTypes.d
+++ b/integrationtest/neo/client/NotifierTypes.d
@@ -12,7 +12,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.NotifierTypes;
+module integrationtest.neo.client.NotifierTypes;
 
 public import swarm.neo.client.NotifierTypes;
 import swarm.neo.util.Formatter;

--- a/integrationtest/neo/client/request/Get.d
+++ b/integrationtest/neo/client/request/Get.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.Get;
+module integrationtest.neo.client.request.Get;
 
 import ocean.transition;
 import ocean.core.SmartUnion;

--- a/integrationtest/neo/client/request/GetAll.d
+++ b/integrationtest/neo/client/request/GetAll.d
@@ -10,11 +10,11 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.GetAll;
+module integrationtest.neo.client.request.GetAll;
 
 import ocean.transition;
 import ocean.core.SmartUnion;
-import test.neo.client.NotifierTypes;
+import integrationtest.neo.client.NotifierTypes;
 
 /*******************************************************************************
 

--- a/integrationtest/neo/client/request/Put.d
+++ b/integrationtest/neo/client/request/Put.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.Put;
+module integrationtest.neo.client.request.Put;
 
 import ocean.transition;
 import ocean.core.SmartUnion;

--- a/integrationtest/neo/client/request/internal/Get.d
+++ b/integrationtest/neo/client/request/internal/Get.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.internal.Get;
+module integrationtest.neo.client.request.internal.Get;
 
 import ocean.transition;
 
@@ -38,9 +38,9 @@ import ocean.transition;
 
 public struct Get
 {
-    import test.neo.common.Get;
-    import test.neo.client.request.Get;
-    import test.neo.common.RequestCodes;
+    import integrationtest.neo.common.Get;
+    import integrationtest.neo.client.request.Get;
+    import integrationtest.neo.common.RequestCodes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers : UseNodeDg;
 

--- a/integrationtest/neo/client/request/internal/GetAll.d
+++ b/integrationtest/neo/client/request/internal/GetAll.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.internal.GetAll;
+module integrationtest.neo.client.request.internal.GetAll;
 
 import ocean.transition;
 
@@ -38,10 +38,10 @@ import ocean.transition;
 
 public struct GetAll
 {
-    import test.neo.common.GetAll;
-    import test.neo.client.request.GetAll;
-    import test.neo.common.RequestCodes;
-    import test.neo.client.NotifierTypes;
+    import integrationtest.neo.common.GetAll;
+    import integrationtest.neo.client.request.GetAll;
+    import integrationtest.neo.common.RequestCodes;
+    import integrationtest.neo.client.NotifierTypes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.mixins.SuspendableRequestCore;
     import swarm.neo.client.mixins.AllNodesRequestCore;
@@ -162,11 +162,11 @@ private scope class GetAllImpl
     import swarm.neo.client.RequestOnConn;
     import swarm.neo.util.MessageFiber;
 
-    import test.neo.common.GetAll;
-    import test.neo.client.NotifierTypes;
+    import integrationtest.neo.common.GetAll;
+    import integrationtest.neo.client.NotifierTypes;
 
-    import test.neo.common.GetAll;
-    import test.neo.client.NotifierTypes;
+    import integrationtest.neo.common.GetAll;
+    import integrationtest.neo.client.NotifierTypes;
 
     /// Connection event dispatcher.
     private RequestOnConn.EventDispatcherAllNodes conn;
@@ -350,8 +350,8 @@ private struct Reader
     import swarm.neo.util.MessageFiber;
     import swarm.neo.request.RequestEventDispatcher;
     import swarm.neo.client.RequestOnConn;
-    import test.neo.common.GetAll;
-    import test.neo.client.NotifierTypes;
+    import integrationtest.neo.common.GetAll;
+    import integrationtest.neo.client.NotifierTypes;
 
     private MessageFiber fiber;
     private RequestEventDispatcher* request_event_dispatcher;
@@ -421,7 +421,7 @@ private struct Controller
     import swarm.neo.request.RequestEventDispatcher;
     import swarm.neo.client.RequestOnConn;
     import swarm.neo.client.mixins.SuspendableRequestCore;
-    import test.neo.common.GetAll;
+    import integrationtest.neo.common.GetAll;
 
     private MessageFiber fiber;
     private RequestEventDispatcher* request_event_dispatcher;

--- a/integrationtest/neo/client/request/internal/Put.d
+++ b/integrationtest/neo/client/request/internal/Put.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.client.request.internal.Put;
+module integrationtest.neo.client.request.internal.Put;
 
 import ocean.transition;
 
@@ -38,9 +38,9 @@ import ocean.transition;
 
 public struct Put
 {
-    import test.neo.common.Put;
-    import test.neo.client.request.Put;
-    import test.neo.common.RequestCodes;
+    import integrationtest.neo.common.Put;
+    import integrationtest.neo.client.request.Put;
+    import integrationtest.neo.common.RequestCodes;
     import swarm.neo.client.mixins.RequestCore;
     import swarm.neo.client.RequestHandlers : UseNodeDg;
 

--- a/integrationtest/neo/common/Get.d
+++ b/integrationtest/neo/common/Get.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.common.Get;
+module integrationtest.neo.common.Get;
 
 import swarm.neo.request.Command;
 

--- a/integrationtest/neo/common/GetAll.d
+++ b/integrationtest/neo/common/GetAll.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.common.GetAll;
+module integrationtest.neo.common.GetAll;
 
 import swarm.neo.request.Command;
 

--- a/integrationtest/neo/common/Put.d
+++ b/integrationtest/neo/common/Put.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.common.Put;
+module integrationtest.neo.common.Put;
 
 import swarm.neo.request.Command;
 

--- a/integrationtest/neo/common/RequestCodes.d
+++ b/integrationtest/neo/common/RequestCodes.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Super simplistic storage implementation of the example node.
+    List of request codes.
 
     Copyright:
         Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
@@ -10,12 +10,12 @@
 
 *******************************************************************************/
 
-module test.neo.node.Storage;
+module integrationtest.neo.common.RequestCodes;
 
-import ocean.transition;
-
-public class Storage
+public enum RequestCode : ubyte
 {
-    /// Values are simply stored in an associative array, indexed by key.
-    public mstring[hash_t] map;
+    None,
+    Put,
+    Get,
+    GetAll
 }

--- a/integrationtest/neo/main.d
+++ b/integrationtest/neo/main.d
@@ -10,7 +10,7 @@
 
 *******************************************************************************/
 
-module test.neo.main;
+module integrationtest.neo.main;
 
 import ocean.transition;
 import ocean.task.Scheduler;
@@ -32,8 +32,8 @@ import ocean.task.Task;
 
 class Test : Task
 {
-    import test.neo.client.Client;
-    import test.neo.node.Node;
+    import integrationtest.neo.client.Client;
+    import integrationtest.neo.node.Node;
 
     import swarm.neo.client.requests.NotificationFormatter;
 
@@ -454,7 +454,8 @@ class Test : Task
 
 *******************************************************************************/
 
-void main ( )
+version (UnitTest) {}
+else void main ( )
 {
     initScheduler(SchedulerConfiguration.init);
     theScheduler.schedule(new Test);

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -17,7 +17,7 @@
 
 *******************************************************************************/
 
-module test.neo.node.Node;
+module integrationtest.neo.node.Node;
 
 import ocean.transition;
 import swarm.node.model.NeoNode;
@@ -30,12 +30,12 @@ public class Node : NodeBase!(ConnHandler)
     import ocean.io.select.EpollSelectDispatcher;
     import swarm.neo.authentication.HmacDef: Key;
 
-    import test.neo.common.RequestCodes;
-    import test.neo.node.Storage;
+    import integrationtest.neo.common.RequestCodes;
+    import integrationtest.neo.node.Storage;
 
-    import Get = test.neo.node.request.Get;
-    import GetAll = test.neo.node.request.GetAll;
-    import Put = test.neo.node.request.Put;
+    import Get = integrationtest.neo.node.request.Get;
+    import GetAll = integrationtest.neo.node.request.GetAll;
+    import Put = integrationtest.neo.node.request.Put;
 
     /// Storage engine.
     private Storage storage;

--- a/integrationtest/neo/node/Storage.d
+++ b/integrationtest/neo/node/Storage.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    List of request codes.
+    Super simplistic storage implementation of the example node.
 
     Copyright:
         Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
@@ -10,12 +10,12 @@
 
 *******************************************************************************/
 
-module test.neo.common.RequestCodes;
+module integrationtest.neo.node.Storage;
 
-public enum RequestCode : ubyte
+import ocean.transition;
+
+public class Storage
 {
-    None,
-    Put,
-    Get,
-    GetAll
+    /// Values are simply stored in an associative array, indexed by key.
+    public mstring[hash_t] map;
 }

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -10,10 +10,10 @@
 
 *******************************************************************************/
 
-module test.neo.node.request.GetAll;
+module integrationtest.neo.node.request.GetAll;
 
 import ocean.transition;
-import test.neo.node.Storage;
+import integrationtest.neo.node.Storage;
 import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
 
@@ -65,7 +65,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
 
 private scope class GetAllImpl_v0
 {
-    import test.neo.common.GetAll;
+    import integrationtest.neo.common.GetAll;
     import swarm.neo.util.MessageFiber;
     import swarm.neo.request.RequestEventDispatcher;
 

--- a/integrationtest/neo/node/request/Put.d
+++ b/integrationtest/neo/node/request/Put.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Internal implementation of the node's Get request.
+    Internal implementation of the node's Put request.
 
     Copyright:
         Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
@@ -10,10 +10,10 @@
 
 *******************************************************************************/
 
-module test.neo.node.request.Get;
+module integrationtest.neo.node.request.Put;
 
 import ocean.transition;
-import test.neo.node.Storage;
+import integrationtest.neo.node.Storage;
 import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
 
@@ -41,7 +41,7 @@ public void handle ( Object shared_resources, RequestOnConn connection,
     switch ( cmdver )
     {
         case 0:
-            scope rq = new GetImpl_v0;
+            scope rq = new PutImpl_v0;
             rq.handle(storage, connection, msg_payload);
             break;
 
@@ -59,13 +59,13 @@ public void handle ( Object shared_resources, RequestOnConn connection,
 
 /*******************************************************************************
 
-    Implementation of the v0 Get request protocol.
+    Implementation of the v0 Put request protocol.
 
 *******************************************************************************/
 
-private scope class GetImpl_v0
+private scope class PutImpl_v0
 {
-    import test.neo.common.Get;
+    import integrationtest.neo.common.Put;
 
     /***************************************************************************
 
@@ -86,34 +86,17 @@ private scope class GetImpl_v0
         auto parser = ed.message_parser;
 
         hash_t key;
-        parser.parseBody(msg_payload, key);
+        cstring value;
+        parser.parseBody(msg_payload, key, value);
 
-        auto record = key in storage.map;
-        if ( record is null )
-        {
-            ed.send(
-                ( ed.Payload payload )
-                {
-                    payload.addConstant(RequestStatusCode.Empty);
-                }
-            );
-        }
-        else
-        {
-            ed.send(
-                ( ed.Payload payload )
-                {
-                    payload.addConstant(RequestStatusCode.Value);
-                }
-            );
+        storage.map[key] = value.dup;
 
-            ed.send(
-                ( ed.Payload payload )
-                {
-                    payload.addArray(*record);
-                }
-            );
-        }
+        ed.send(
+            ( ed.Payload payload )
+            {
+                payload.addConstant(RequestStatusCode.Succeeded);
+            }
+        );
         ed.flush();
     }
 }


### PR DESCRIPTION
Makd v2.x.x expects the integration test suite inside
integrationtest/ directory, not inside test/. This renames
test/ into integrationtest/, guards `main` methods with
`version(!UnitTest)` and runs the integration tests again.