### PR TITLE
Add missing enableStomping() in BatchReader constructor

### DIFF
--- a/src/swarm/neo/util/Batch.d
+++ b/src/swarm/neo/util/Batch.d
@@ -318,6 +318,7 @@ public scope class BatchReader ( Record ... )
         // Read uncompressed length from first size_t.sizeof bytes.
         auto uncompressed_len = *(cast(size_t*)(batch.ptr));
         decompress_buf.length = uncompressed_len;
+        enableStomping(decompress_buf);
 
         // Decompress into this.batch.
         auto src = batch[size_t.sizeof .. $];


### PR DESCRIPTION
Detected in dhtproto testing https://travis-ci.org/sociomantic-tsunami/dhtproto/jobs/319197884.