### PR TITLE
Modify per-version request handler support to use ClassInfo, not handler function

### DIFF
--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -34,10 +34,10 @@ public class Node : NodeBase!(ConnHandler)
     import integrationtest.neo.common.RequestCodes;
     import integrationtest.neo.node.Storage;
 
-    import Get = integrationtest.neo.node.request.Get;
-    import GetAll = integrationtest.neo.node.request.GetAll;
-    import Put = integrationtest.neo.node.request.Put;
-    import DoublePut = integrationtest.neo.node.request.DoublePut;
+    import integrationtest.neo.node.request.Get;
+    import integrationtest.neo.node.request.GetAll;
+    import integrationtest.neo.node.request.Put;
+    import integrationtest.neo.node.request.DoublePut;
 
     /***************************************************************************
 
@@ -65,13 +65,13 @@ public class Node : NodeBase!(ConnHandler)
         options.epoll = epoll;
 
         options.requests.add(Command(RequestCode.Get, 0),
-            "Get", &Get.handle_v0);
+            "Get", GetImpl_v0.classinfo);
         options.requests.add(Command(RequestCode.GetAll, 0),
-            "GetAll", &GetAll.handle_v0);
+            "GetAll", GetAllImpl_v0.classinfo);
         options.requests.add(Command(RequestCode.Put, 0),
-            "Put", &Put.handle_v0);
+            "Put", PutImpl_v0.classinfo);
         options.requests.add(Command(RequestCode.DoublePut, 0),
-            "DoublePut", &DoublePut.handle_v0);
+            "DoublePut", DoublePutImpl_v0.classinfo);
 
         options.credentials_map["dummy"] = Key.init;
         options.shared_resources = this.shared_resources;
@@ -95,6 +95,24 @@ public class Node : NodeBase!(ConnHandler)
     override protected cstring id ( )
     {
         return "example";
+    }
+
+    /***************************************************************************
+
+        Scope allocates a request resource acquirer backed by the protected
+        `shared_resources`. (Passed as a generic Object to avoid templatising
+        this class and others that depend on it.)
+
+        Params:
+            handle_request_dg = delegate that receives a resources acquirer and
+                initiates handling of a request
+
+    ***************************************************************************/
+
+    override protected void getResourceAcquirer (
+        void delegate ( Object resource_acquirer ) handle_request_dg )
+    {
+        handle_request_dg(this.shared_resources);
     }
 }
 

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -39,9 +39,6 @@ public class Node : NodeBase!(ConnHandler)
     import Put = integrationtest.neo.node.request.Put;
     import DoublePut = integrationtest.neo.node.request.DoublePut;
 
-    /// Storage engine.
-    private Storage storage;
-
     /***************************************************************************
 
         Constructor.
@@ -60,7 +57,9 @@ public class Node : NodeBase!(ConnHandler)
     }
     body
     {
-        this.storage = new Storage;
+        // In this simple example node implementation, we don't need any shared
+        // resources except the reference to the storage.
+        this.shared_resources = new Storage;
 
         Options options;
         options.epoll = epoll;
@@ -75,7 +74,7 @@ public class Node : NodeBase!(ConnHandler)
             "DoublePut", &DoublePut.handle_v0);
 
         options.credentials_map["dummy"] = Key.init;
-        options.shared_resources = this.storage;
+        options.shared_resources = this.shared_resources;
 
         const backlog = 1_000;
         auto legacy_port = NodeItem(addr.dup, cast(ushort)(neo_port - 1));

--- a/integrationtest/neo/node/request/DoublePut.d
+++ b/integrationtest/neo/node/request/DoublePut.d
@@ -16,31 +16,7 @@ import ocean.transition;
 import integrationtest.neo.node.Storage;
 import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
-
-/*******************************************************************************
-
-    The request handler for the table of handlers. When called, runs in a fiber
-    that can be controlled via `connection`.
-
-    Params:
-        shared_resources = an opaque object containing resources owned by the
-            node which are required by the request
-        connection  = performs connection socket I/O and manages the fiber
-        cmdver      = the version number of the Consume command as specified by
-                      the client
-        msg_payload = the payload of the first message of this request
-
-*******************************************************************************/
-
-public void handle_v0 ( Object shared_resources, RequestOnConn connection,
-    Command.Version cmdver, Const!(void)[] msg_payload )
-{
-    auto storage = cast(Storage)shared_resources;
-    assert(storage);
-
-    scope rq = new DoublePutImpl_v0;
-    rq.handle(storage, connection, msg_payload);
-}
+import swarm.neo.node.IRequestHandler;
 
 /*******************************************************************************
 
@@ -48,34 +24,53 @@ public void handle_v0 ( Object shared_resources, RequestOnConn connection,
 
 *******************************************************************************/
 
-private scope class DoublePutImpl_v0
+public class DoublePutImpl_v0 : IRequestHandler
 {
     import integrationtest.neo.common.DoublePut;
+    import integrationtest.neo.node.request.mixins.RequestCore;
+
+    mixin RequestCore!();
 
     /***************************************************************************
 
-        Request handler.
+        Called by the connection handler immediately after the request code and
+        version have been parsed from a message received over the connection.
+        Allows the request handler to process the remainder of the incoming
+        message, before the connection handler sends the supported code back to
+        the client.
+
+        Note: the initial payload is a slice of the connection's read buffer.
+        This means that when the request-on-conn fiber suspends, the contents of
+        the buffer (hence the slice) may change. It is thus *absolutely
+        essential* that this method does not suspend the fiber. (This precludes
+        all I/O operations on the connection.)
 
         Params:
-            storage = storage engine instance to operate on
-            connection = connection to client
-            msg_payload = initial message read from client to begin the request
-                (the request code and version are assumed to be extracted)
+            init_payload = initial message payload read from the connection
 
     ***************************************************************************/
 
-    final public void handle ( Storage storage, RequestOnConn connection,
-        Const!(void)[] msg_payload )
+    public void preSupportedCodeSent ( Const!(void)[] init_payload )
     {
-        auto ed = connection.event_dispatcher;
-        auto parser = ed.message_parser;
+        auto parser = this.connection.event_dispatcher.message_parser;
 
         hash_t key;
         cstring value;
-        parser.parseBody(msg_payload, key, value);
+        parser.parseBody(init_payload, key, value);
 
-        storage.map[key] = value.dup;
+        this.storage.map[key] = value.dup;
+    }
 
+    /***************************************************************************
+
+        Called by the connection handler after the supported code has been sent
+        back to the client.
+
+    ***************************************************************************/
+
+    public void postSupportedCodeSent ( )
+    {
+        auto ed = this.connection.event_dispatcher;
         ed.send(
             ( ed.Payload payload )
             {

--- a/integrationtest/neo/node/request/Get.d
+++ b/integrationtest/neo/node/request/Get.d
@@ -16,31 +16,7 @@ import ocean.transition;
 import integrationtest.neo.node.Storage;
 import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
-
-/*******************************************************************************
-
-    The request handler for the table of handlers. When called, runs in a fiber
-    that can be controlled via `connection`.
-
-    Params:
-        shared_resources = an opaque object containing resources owned by the
-            node which are required by the request
-        connection  = performs connection socket I/O and manages the fiber
-        cmdver      = the version number of the Consume command as specified by
-                      the client
-        msg_payload = the payload of the first message of this request
-
-*******************************************************************************/
-
-public void handle_v0 ( Object shared_resources, RequestOnConn connection,
-    Command.Version cmdver, Const!(void)[] msg_payload )
-{
-    auto storage = cast(Storage)shared_resources;
-    assert(storage);
-
-    scope rq = new GetImpl_v0;
-    rq.handle(storage, connection, msg_payload);
-}
+import swarm.neo.node.IRequestHandler;
 
 /*******************************************************************************
 
@@ -48,32 +24,53 @@ public void handle_v0 ( Object shared_resources, RequestOnConn connection,
 
 *******************************************************************************/
 
-private scope class GetImpl_v0
+public class GetImpl_v0 : IRequestHandler
 {
     import integrationtest.neo.common.Get;
+    import integrationtest.neo.node.request.mixins.RequestCore;
+
+    mixin RequestCore!();
+
+    /// Key of record to get.
+    private hash_t key;
 
     /***************************************************************************
 
-        Request handler.
+        Called by the connection handler immediately after the request code and
+        version have been parsed from a message received over the connection.
+        Allows the request handler to process the remainder of the incoming
+        message, before the connection handler sends the supported code back to
+        the client.
+
+        Note: the initial payload is a slice of the connection's read buffer.
+        This means that when the request-on-conn fiber suspends, the contents of
+        the buffer (hence the slice) may change. It is thus *absolutely
+        essential* that this method does not suspend the fiber. (This precludes
+        all I/O operations on the connection.)
 
         Params:
-            storage = storage engine instance to operate on
-            connection = connection to client
-            msg_payload = initial message read from client to begin the request
-                (the request code and version are assumed to be extracted)
+            init_payload = initial message payload read from the connection
 
     ***************************************************************************/
 
-    final public void handle ( Storage storage, RequestOnConn connection,
-        Const!(void)[] msg_payload )
+    public void preSupportedCodeSent ( Const!(void)[] init_payload )
     {
-        auto ed = connection.event_dispatcher;
-        auto parser = ed.message_parser;
+        auto parser = this.connection.event_dispatcher.message_parser;
+        parser.parseBody(init_payload, this.key);
+    }
 
-        hash_t key;
-        parser.parseBody(msg_payload, key);
+    /***************************************************************************
 
-        auto record = key in storage.map;
+        Called by the connection handler after the supported code has been sent
+        back to the client.
+
+    ***************************************************************************/
+
+    public void postSupportedCodeSent ( )
+    {
+        auto ed = this.connection.event_dispatcher;
+
+        auto record = this.key in this.storage.map;
         if ( record is null )
         {
             ed.send(

--- a/integrationtest/neo/node/request/Put.d
+++ b/integrationtest/neo/node/request/Put.d
@@ -16,31 +16,7 @@ import ocean.transition;
 import integrationtest.neo.node.Storage;
 import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
-
-/*******************************************************************************
-
-    The request handler for the table of handlers. When called, runs in a fiber
-    that can be controlled via `connection`.
-
-    Params:
-        shared_resources = an opaque object containing resources owned by the
-            node which are required by the request
-        connection  = performs connection socket I/O and manages the fiber
-        cmdver      = the version number of the Consume command as specified by
-                      the client
-        msg_payload = the payload of the first message of this request
-
-*******************************************************************************/
-
-public void handle_v0 ( Object shared_resources, RequestOnConn connection,
-    Command.Version cmdver, Const!(void)[] msg_payload )
-{
-    auto storage = cast(Storage)shared_resources;
-    assert(storage);
-
-    scope rq = new PutImpl_v0;
-    rq.handle(storage, connection, msg_payload);
-}
+import swarm.neo.node.IRequestHandler;
 
 /*******************************************************************************
 
@@ -48,34 +24,53 @@ public void handle_v0 ( Object shared_resources, RequestOnConn connection,
 
 *******************************************************************************/
 
-private scope class PutImpl_v0
+public class PutImpl_v0 : IRequestHandler
 {
     import integrationtest.neo.common.Put;
+    import integrationtest.neo.node.request.mixins.RequestCore;
+
+    mixin RequestCore!();
 
     /***************************************************************************
 
-        Request handler.
+        Called by the connection handler immediately after the request code and
+        version have been parsed from a message received over the connection.
+        Allows the request handler to process the remainder of the incoming
+        message, before the connection handler sends the supported code back to
+        the client.
+
+        Note: the initial payload is a slice of the connection's read buffer.
+        This means that when the request-on-conn fiber suspends, the contents of
+        the buffer (hence the slice) may change. It is thus *absolutely
+        essential* that this method does not suspend the fiber. (This precludes
+        all I/O operations on the connection.)
 
         Params:
-            storage = storage engine instance to operate on
-            connection = connection to client
-            msg_payload = initial message read from client to begin the request
-                (the request code and version are assumed to be extracted)
+            init_payload = initial message payload read from the connection
 
     ***************************************************************************/
 
-    final public void handle ( Storage storage, RequestOnConn connection,
-        Const!(void)[] msg_payload )
+    public void preSupportedCodeSent ( Const!(void)[] init_payload )
     {
-        auto ed = connection.event_dispatcher;
-        auto parser = ed.message_parser;
+        auto parser = this.connection.event_dispatcher.message_parser;
 
         hash_t key;
         cstring value;
-        parser.parseBody(msg_payload, key, value);
+        parser.parseBody(init_payload, key, value);
 
-        storage.map[key] = value.dup;
+        this.storage.map[key] = value.dup;
+    }
 
+    /***************************************************************************
+
+        Called by the connection handler after the supported code has been sent
+        back to the client.
+
+    ***************************************************************************/
+
+    public void postSupportedCodeSent ( )
+    {
+        auto ed = this.connection.event_dispatcher;
         ed.send(
             ( ed.Payload payload )
             {

--- a/integrationtest/neo/node/request/mixins/RequestCore.d
+++ b/integrationtest/neo/node/request/mixins/RequestCore.d
@@ -1,0 +1,42 @@
+/*******************************************************************************
+
+    Request handler class initialisation boilerplate.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.neo.node.request.mixins.RequestCore;
+
+template RequestCore ( )
+{
+    import swarm.neo.node.RequestOnConn;
+    import integrationtest.neo.node.Storage;
+
+    /// Request-on-conn of this request handler.
+    private RequestOnConn connection;
+
+    /// Storage.
+    private Storage storage;
+
+    /***************************************************************************
+
+        Passes the request-on-conn and request resource acquirer to the handler.
+
+        Params:
+            connection = request-on-conn in which the request handler is called
+            resources = request resources acquirer
+
+    ***************************************************************************/
+
+    public void initialise ( RequestOnConn connection, Object resources )
+    {
+        this.connection = connection;
+        this.storage = cast(Storage)resources;
+        assert(this.storage !is null);
+    }
+}

--- a/relnotes/request-handlers.feature.md
+++ b/relnotes/request-handlers.feature.md
@@ -1,11 +1,17 @@
 ## Node's map of request handlers now works per request _version_
 
-`swarm.neo.node.ConnectionHandler`
+`swarm.neo.node.ConnectionHandler`, `swarm.neo.node.IRequestHandler`
 
 A new overload of `ConnectionHandler.RequestMap.add` allows request information
-(including a handler function) to be mapped by a `Command` struct instance (see
-`swarm.neo.request.Command`). The important point here is that a `Command`
-struct instance describes a specific _version_ of a request. Thus, different
-request information (in particular, handler functions) can be provided for each
-version of a request.
+(including a `ClassInfo` denoting a request handler class to use) to be mapped
+by a `Command` struct instance (see `swarm.neo.request.Command`). The important
+point here is that a `Command` struct instance describes a specific _version_ of
+a request. Thus, different request information (in particular, handler classes)
+can be provided for each version of a request.
+
+For requests registered with this new method, the node will automatically send
+an un/supported code to the client.
+
+Requests that wish to use this new system must implement the new
+`IRequestHandler` interface.
 

--- a/src/swarm/neo/node/IRequestHandler.d
+++ b/src/swarm/neo/node/IRequestHandler.d
@@ -1,0 +1,66 @@
+/*******************************************************************************
+
+    Interface for a node request handler object.
+
+    Note that the `ConnectionHandler` (which uses this interface) requires
+    implementing classes to have neither constructors nor destructors. The
+    reason for this is documented in `ConnectionHandler.emplace`.
+
+    copyright: Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module swarm.neo.node.IRequestHandler;
+
+/// ditto
+public interface IRequestHandler
+{
+    import ocean.transition;
+
+    import swarm.neo.node.RequestOnConn;
+
+    /***************************************************************************
+
+        Passes the request-on-conn and request resource acquirer to the handler.
+
+        Params:
+            connection = request-on-conn in which the request handler is called
+            resources = request resources acquirer
+
+    ***************************************************************************/
+
+    void initialise ( RequestOnConn connection, Object resources );
+
+    /***************************************************************************
+
+        Called by the connection handler immediately after the request code and
+        version have been parsed from a message received over the connection.
+        Allows the request handler to process the remainder of the incoming
+        message, before the connection handler sends the supported code back to
+        the client.
+
+        Note: the initial payload is a slice of the connection's read buffer.
+        This means that when the request-on-conn fiber suspends, the contents of
+        the buffer (hence the slice) may change. It is thus *absolutely
+        essential* that this method does not suspend the fiber. (This precludes
+        all I/O operations on the connection.)
+
+        Params:
+            init_payload = initial message payload read from the connection
+
+    ***************************************************************************/
+
+    void preSupportedCodeSent ( Const!(void)[] init_payload );
+
+    /***************************************************************************
+
+        Called by the connection handler after the supported code has been sent
+        back to the client.
+
+    ***************************************************************************/
+
+    void postSupportedCodeSent ( );
+}

--- a/src/swarm/neo/node/RequestOnConn.d
+++ b/src/swarm/neo/node/RequestOnConn.d
@@ -39,6 +39,18 @@ abstract class RequestOnConn: RequestOnConnBase
 
     /***************************************************************************
 
+        Re-usable buffer used by COnnectionHandler to emplace request handler
+        objects into. (Instead of heap allocating an instance every time a
+        request is handled.) We use a heap buffer, rather than a fixed-size
+        array on the stack, in order to not have to guess the maximum size of a
+        request handler object.
+
+    ***************************************************************************/
+
+    public void[] emplace_buf;
+
+    /***************************************************************************
+
         The event dispatcher to communicate to the client.
 
     ***************************************************************************/

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -632,7 +632,8 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
     ***************************************************************************/
 
     public alias SelectListener!(ConnHandler, ConnectionSetupParams) Listener;
-    public alias SelectListener!(Neo.ConnectionHandler, Neo.ConnectionHandler.SharedParams) NeoListener;
+    public alias SelectListener!(Neo.ConnectionHandler,
+        Neo.ConnectionHandler.SharedParams) NeoListener;
 
     /***************************************************************************
 
@@ -777,8 +778,6 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
         this.shared_resources = options.shared_resources;
 
         InetAddress!(false) addr, neo_addr;
-        alias SelectListener!(Neo.ConnectionHandler,
-            Neo.ConnectionHandler.SharedParams) NeoListener;
 
         // Create listener sockets.
         this.socket = new AddressIPSocket!();
@@ -809,7 +808,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
         // Instantiate params object shared by all neo connection handlers.
         auto neo_conn_setup_params = new Neo.ConnectionHandler.SharedParams(
             options.epoll, options.shared_resources, options.requests,
-            options.no_delay, *credentials, this);
+            options.no_delay, *credentials, this, &this.getResourceAcquirer);
 
         // Set up unix listener socket, if specified.
         UnixListener unix_listener;
@@ -902,6 +901,27 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
         }
 
         return ret;
+    }
+
+    /***************************************************************************
+
+        Scope allocates a request resource acquirer backed by the protected
+        `shared_resources`. (Passed as a generic Object to avoid templatising
+        this class and others that depend on it.)
+
+        Params:
+            handle_request_dg = delegate that receives a resources acquirer and
+                initiates handling of a request
+
+    ***************************************************************************/
+
+    protected void getResourceAcquirer (
+        void delegate ( Object resource_acquirer ) handle_request_dg )
+    {
+        // Default implementation does nothing. The derived class should
+        // override and provide the expected logic.
+        // TODO: make this method abstract in the next major. (Obligatory
+        // keyword: deprecated.)
     }
 
     /***************************************************************************

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -749,6 +749,14 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
     /***************************************************************************
 
+        The opaque shared resources instance.
+
+    ***************************************************************************/
+
+    protected Object shared_resources;
+
+    /***************************************************************************
+
         Constructor
 
         Params:
@@ -765,6 +773,8 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
                   int backlog )
     {
         assert(options.epoll !is null);
+
+        this.shared_resources = options.shared_resources;
 
         InetAddress!(false) addr, neo_addr;
         alias SelectListener!(Neo.ConnectionHandler,


### PR DESCRIPTION
The impetus for this change is to fix the issue discovered in
sociomantic-tsunami/dhtproto#93:
* The initial message payload of a request is a slice of the socket input
  buffer.
* Hence, when the request-on-conn suspends, the contents of the initial
  message payload may change.
* Moving the sending of the un/supported code into swarm changed the behaviour of
  request handlers, in that the handler might be called after the
  request-on-conn has been suspended and resumed. Thus, the contents of the
  initial payload buffer might have changed. = data corruption.

This change also has the nice side-effect of moving a lot of request
handling boilerplate into swarm.

Fixes #227.

(Note that this is a breaking change to an as yet unreleased new feature of v4.6.0.)