### PR TITLE
 Adapt RequestEventDispatcher to reuse the internal arrays 

### DIFF
--- a/integrationtest/neo/client/request/internal/GetAll.d
+++ b/integrationtest/neo/client/request/internal/GetAll.d
@@ -276,6 +276,14 @@ private scope class GetAllImpl
         Reader reader;
         Controller controller;
 
+        // Initialise the RequestEventDispatcher with the delegate that returns
+        // (reusable) void[] arrays for the internal usage. The real implementation
+        // should pass the delegate that acquires the arrays from the pool,
+        // this implementation just returns pointers to the new slices, as we
+        // don't care about GC activity here.
+        request_event_dispatcher.initialise(
+                () { auto slices = new void[][1]; return &slices[0]; });
+
         // Note: this request heap allocates two fibers each time it is handled.
         // In a real client implementation, you would want to get these fibers
         // from a pool, to avoid allocating each time.

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -208,6 +208,14 @@ private scope class GetAllImpl_v0
             this.storage = storage;
             this.conn = connection.event_dispatcher;
 
+            // Initialise the RequestEventDispatcher with the delegate that
+            // returns (reusable) void[] arrays for the internal usage. The
+            // real implementation should pass the delegate that acquires the
+            // arrays from the pool, this implementation just returns pointers
+            // to the new slices, as we don't care about GC activity here.
+            this.request_event_dispatcher.initialise(
+                    () { auto slices = new void[][1]; return &slices[0]; });
+
             // Read request setup info from client.
             bool start_suspended;
             this.conn.message_parser.parseBody(msg_payload, start_suspended);

--- a/relnotes/requestdispatcher.migration.md
+++ b/relnotes/requestdispatcher.migration.md
@@ -1,0 +1,8 @@
+## Adapt `RequestEventDispatcher` usage to new `initialise` method: don't store in a pool
+
+`swarm.neo.request.RequestEventDispatcher`
+
+It's no longer recommended to keep the reusable RequestEventDispatcher instance,
+instead it should reuse the internal arrays (obtained by the delegate passed
+to the `initialise` method). All code using it must adapt to use the `initialise`
+method in conjunction with `AcquiredResources.getVoidBuffer()` method.


### PR DESCRIPTION
RequestEventDispatcher is now adapted to accept reusable arrays used
internally, so the instance of it doesn't need to be stored in the pool.
Instead, every request can instantiate one, backed by the pooled arrays,
avoiding to maintain the separate pool of RequestEventDispatcher.

Blocked on fine v5.x.x branch.