### PR TITLE
 Explicitly allow manual resume in EventDispatcher.nextEvent 

### DIFF
--- a/relnotes/nextevent.migration.md
+++ b/relnotes/nextevent.migration.md
@@ -1,0 +1,19 @@
+## EventDispatcher.nextEvent doesn't implicitly allow explicit resume
+
+`swarm.neo.connection.RequestOnConnBase`
+
+The EventDispatcher.nextEvent method suspends the fiber and ensures that it is
+only resumed again for an expected reason. Previously, in addition to the
+resume reasons specified by the user when calling the method, manual resumption
+of the fiber with a positive resume code was always implicitly allowed. This
+meant that user code had to manually check for this case, if it was not
+desired.
+
+Now, manual resumption of the fiber is disallowed by default, and
+EventDispatcher.nextEvent will by default treat this as a protocol error, if it
+occurs. Code that calls nextEvent should be updated as follows:
+
+   - If you wish to allow manual fiber resumption,
+     pass the new NextEventFlags.Resume flag to nextEvent.
+   - If you wish to disallow manual fiber resumption, do nothing. For tidiness,
+     you should remove any user code that checks for this occurrence.


### PR DESCRIPTION
EventDispatcher.nextEvent accepts the flags, such as Receive, which will
make nextEvent not throw an exception if the fiber is resumed with the
data received - the default behavior is to allow resuming fiber for the
reasons explicitly specified in the nextEvent call.

This behavior allows caller not to check the reason why the fiber was
resumed - except in one case: the nextEvent will always allow explicit
resume from the code with the positive resume code. This in turn makes
user always to check that the resume reason is not explicit resume (with
positive resume code). As this is allowed on relatively rare occasions,
it seems that it might be better if the user would explicitly allow
resuming the fiber (with another NextEventFlag).

This changes the logic so that the explicit `NextEventFlag.Resume` is
added, so the clients that want to be resumed should use it and they can
then drop the assertion that the fiber was not resumed manually from the
places they don't want this behaviour.

Fixes #154