### PR TITLE
Add turtle submodule and the common fake node base

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "beaver"]
 	path = submodules/beaver
 	url = https://github.com/sociomantic-tsunami/beaver.git
+[submodule "turtle"]
+	path = submodules/turtle
+	url = https://github.com/sociomantic-tsunami/turtle.git

--- a/integrationtest/turtleenv/main.d
+++ b/integrationtest/turtleenv/main.d
@@ -1,0 +1,114 @@
+/*******************************************************************************
+
+    Test of the abstract turtle node extension.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.turtleenv.main;
+
+import swarm.neo.AddrPort;
+import turtle.env.model.Node;
+import ocean.util.test.DirectorySandbox;
+import ocean.core.Test;
+import ocean.io.device.File;
+
+/// Node used to the turtle test
+private class TurtleNode
+{
+    /// Address and the port of the node
+    AddrPort addrport;
+    AddrPort neo_address;
+
+    this (AddrPort addrport)
+    {
+        this.addrport = addrport;
+        this.neo_address = AddrPort(this.addrport.address());
+        this.neo_address.port = cast(ushort)(this.addrport.port() + 100);
+    }
+}
+
+/// The turlte TurtleNode class
+private class TestNode : Node!(TurtleNode, "turtleNode")
+{
+    /***********************************************************************
+
+        Creates a fake node at the specified address/port.
+
+        Params:
+            node_item = address/port
+
+    ***********************************************************************/
+
+    override protected TurtleNode createNode ( AddrPort addrport )
+    {
+        return new TurtleNode(addrport);
+    }
+
+    /***********************************************************************
+
+        Returns:
+            address/port on which node is listening
+
+    ***********************************************************************/
+
+    override public AddrPort node_addrport ( )
+    {
+        assert(this.node);
+        return this.node.addrport;
+    }
+
+    /***********************************************************************
+
+        Fake node service stop implementation.
+
+    ***********************************************************************/
+
+    protected override void stopImpl ( )
+    {
+    }
+
+    /***********************************************************************
+
+        Removes all data from the fake node service.
+
+    ***********************************************************************/
+
+    override public void clear ( )
+    {
+    }
+
+    /***********************************************************************
+
+        Suppresses log output from the fake node if used version of proto
+        supports it.
+
+    ***********************************************************************/
+
+    override public void log_errors ( bool log_errors )
+    {
+        static if (is(typeof(this.node.log_errors(log_errors))))
+            this.node.log_errors(log_errors);
+    }
+}
+
+version (UnitTest){}
+else
+void main()
+{
+    auto sandbox = DirectorySandbox.create();
+    scope (success)
+        sandbox.remove();
+
+    auto node = new TestNode();
+    node.start("127.0.0.1", 10000);
+    node.genConfigFiles(".");
+
+    test!("==")(File.get("turtleNode.nodes"), "127.0.0.1:10000\n");
+    test!("==")(File.get("turtleNode.neo.nodes"), "127.0.0.1:10100\n");
+}

--- a/relnotes/turtleenv.migration.md
+++ b/relnotes/turtleenv.migration.md
@@ -1,0 +1,32 @@
+## Turtle Node ext base class is now in swarm
+
+`turtle.env.model.Node`
+
+This module providing the common turtle ext node base class used to be included
+in the protos. Because it's the same file, it's now moved into swarm. Proto
+repositories should remove their copy of this file.
+
+Couple of changes needs to be performed while updating the protos' implementations,
+and client code:
+
+- `ignoreErrors()` is now renamed to `log_errors(bool)` method which can
+  enable/disable the error output.
+
+- `node_item()` method has renamed to `node_addport` and now it returns
+  `AddrPort` structure. Make sure you don't set the port/address directly,
+  as the byte order might be different. Use setAddress()/port() setters/getters.
+  For example:
+
+      // Before:
+
+      this.neo_address = NodeItem(this.node_item.address, this.node_item.port() + 100);
+
+      // After:
+
+      this.neo_address = AddrPort(this.node_item.address)
+
+      // Important - port setter converts from host to network byte order
+      this.neo_address.port() = cast(ushort)this.node_item.port() + 100;
+
+- `createNode` (protected method) now accepts `AddrPort` structure instead
+  `NodeItem` structure.

--- a/src/turtle/env/model/Node.d
+++ b/src/turtle/env/model/Node.d
@@ -1,0 +1,250 @@
+/*******************************************************************************
+
+    Abstract fake node for integration with turtle's registry of env additions.
+
+    Copyright:
+        Copyright (c) 2015-2018 sociomantic labs GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module turtle.env.model.Node;
+
+import ocean.transition;
+import ocean.text.convert.Formatter;
+import turtle.env.model.Registry;
+import ocean.core.Verify;
+
+/*******************************************************************************
+
+    Abstract fake node for integration with trutle's registry of env additions.
+
+    Also includes methods for starting and stopping the fake node.
+
+    Note: this class and derivatives are only used when running tests which need
+    to *access* a node (the turtle env addition provides a fake node which can
+    be inspected and modified by test cases). It is not relevant when running
+    tests *on* a node implementation itself.
+
+    Params:
+        NodeType = type of the node server implementation
+        id = name of the node type. Used for .nodes file name formatting
+
+*******************************************************************************/
+
+public abstract class Node ( NodeType, istring id ) : ITurtleEnv
+{
+    import swarm.Const : NodeItem;
+    import swarm.neo.AddrPort;
+    import ocean.io.device.File;
+    import ocean.core.Buffer;
+    import turtle.env.Shell;
+    import Integer = ocean.text.convert.Integer_tango;
+
+    /// Enum defining the possibles states of the fake node service.
+    private enum State
+    {
+        Init,
+        Running,
+        Stopped
+    }
+
+    /// State of the fake node service.
+    private State state;
+
+    /// Used to prevent creating multiple fake nodes of the same type.
+    static bool already_created = false;
+
+    /// Node service object. Instantiated when start() is called.
+    protected NodeType node;
+
+    /***************************************************************************
+
+        Constructor
+
+    ***************************************************************************/
+
+    public this ( )
+    {
+        verify(!already_created, "Can only have one " ~ id ~ " per turtle test app");
+        already_created = true;
+    }
+
+    /***************************************************************************
+
+        Starts the fake node as part of test suite event loop. It will
+        only terminate when whole test suite process dies.
+
+        Params:
+            addr = address to bind listening socket to
+            port = port to bind listening socket to
+
+    ***************************************************************************/
+
+    public void start ( cstring addr = "127.0.0.1", ushort port = 0 )
+    {
+        verify(this.state == State.Init, "Node has already been started");
+
+        AddrPort addrport;
+        addrport.setAddress(addr.dup);
+        addrport.port = port;
+        this.node = this.createNode(addrport);
+        this.state = State.Running;
+
+        turtle_env_registry.register(this);
+    }
+
+    /***************************************************************************
+
+        Restarts the fake node, reopening the listening socket on the same port
+        determined in the initial call to start().
+
+        Notes:
+            1. Restarting the node *does not* clear any data in its storage
+               engine. To do that, call reset().
+            2. You must call stop() first, before calling restart().
+
+    ***************************************************************************/
+
+    public void restart ( )
+    {
+        verify(this.state == State.Stopped, "Node has not been stopped");
+
+        this.node = this.createNode(this.node_addrport);
+        this.state = State.Running;
+    }
+
+    /***************************************************************************
+
+        Stops the fake node service. The node may be started again on the same
+        port via restart().
+
+    ***************************************************************************/
+
+    final public void stop ( )
+    {
+        verify(this.state == State.Running, "Node is not running");
+
+        this.stopImpl();
+        this.state = State.Stopped;
+    }
+
+    /***************************************************************************
+
+        Does hard reset of the node with terminating all persistent requests.
+        Aliases to `clear` by default for backwards compatibility.
+
+    ***************************************************************************/
+
+    public void reset ( )
+    {
+        this.clear();
+    }
+
+    /***************************************************************************
+
+        Generate nodes files for the fake nodes. If the node supports the neo
+        protocol then the neo nodes file will also be written.
+
+        Params:
+            directory = The directory the files will be written to.
+
+    ***************************************************************************/
+
+    public void genConfigFiles ( cstring directory )
+    {
+        shell("mkdir -p " ~ directory);
+
+        auto legacyfile = new File(directory ~ "/" ~ id ~ ".nodes",
+            File.WriteCreate);
+        scope (exit) legacyfile.close();
+
+        auto node_address = format("{}.{}.{}.{}",
+            this.node_addrport.address_bytes[0],
+            this.node_addrport.address_bytes[1],
+            this.node_addrport.address_bytes[2],
+            this.node_addrport.address_bytes[3]);
+
+        legacyfile.write(node_address ~ ":" ~
+            Integer.toString(this.node_addrport.port));
+        legacyfile.write("\n");
+
+        static if ( is(typeof(this.node.neo_address)) )
+        {
+            auto neofile = new File(directory ~ "/" ~ id ~ ".neo.nodes",
+                File.WriteCreate);
+            scope (exit) neofile.close();
+
+            neofile.write(node_address ~ ":" ~
+                Integer.toString(this.node.neo_address.port));
+            neofile.write("\n");
+        }
+    }
+
+    /***************************************************************************
+
+        ITurtleEnv interface method implementation. Should not be called
+        manually.
+
+        Uses turtle env addition registry to stop tracking errors after all
+        tests have finished. This is necessary because applications don't do
+        clean connection shutdown when terminating, resulting in socker errors
+        being reported on node side.
+
+    ***************************************************************************/
+
+    public void unregister ( )
+    {
+        this.log_errors(false);
+    }
+
+    /***************************************************************************
+
+        Creates a fake node at the specified address/port.
+
+        Params:
+            node_addrport = address/port
+
+    ***************************************************************************/
+
+    abstract protected NodeType createNode ( AddrPort node_addrport );
+
+    /***************************************************************************
+
+        Returns:
+            address/port on which node is listening
+
+    ***************************************************************************/
+
+    abstract public AddrPort node_addrport ( );
+
+    /***************************************************************************
+
+        Fake node service stop implementation.
+
+    ***************************************************************************/
+
+    abstract protected void stopImpl ( );
+
+    /***************************************************************************
+
+        Removes all data from the fake node service.
+
+    ***************************************************************************/
+
+    abstract public void clear ( );
+
+    /***************************************************************************
+
+        Suppresses/allows log output from the fake node if used version of node
+        proto supports it.
+
+        Params:
+            log = true to log errors, false to stop logging errors
+
+    ***************************************************************************/
+
+    abstract public void log_errors ( bool log );
+}


### PR DESCRIPTION
Fake test implementations of the proto repositories share the same base
class that's used by turtle to bootstrap the tests. Instead of having
this code duplicated in protos, it's included in swarm (as part of
turtle.* package).

Fixes #47