### PR TITLE
Add note about passing error callbacks to the node ctor

### DIFF
--- a/src/swarm/node/model/Node.d
+++ b/src/swarm/node/model/Node.d
@@ -178,7 +178,10 @@ public abstract class INodeBase : INode, INodeInfo
 
         Params:
             node = node addres & port
-            conn_setup_params = connection handler constructor arguments
+            conn_setup_params = connection handler constructor arguments.
+                Note that the `error_dg` field should not be set by the user; it
+                is set internally. To set a user-defined error callback, use the
+                `error_callback` method
             listener = select listener, is evaluated exactly once after
                        conn_setup_params have been populated
 


### PR DESCRIPTION
The contradiction between allowing the user to specify this callback and
then overwriting it indicates a weird design in the node framework (no
surprise). The current framework should be fixed at some point, but that's
a large refactoring effort. For now, just a note about the odd behaviour.

Fixes #58.