### PR TITLE
Adapt all-nodes / suspendable request cores to auto handle supported codes

### DIFF
--- a/integrationtest/neo/client/request/internal/GetAll.d
+++ b/integrationtest/neo/client/request/internal/GetAll.d
@@ -184,8 +184,7 @@ private scope class GetAllImpl
     public void run ( )
     {
         auto request = createSuspendableRequest!(GetAll)(this.conn, this.context,
-            &this.connect, &this.disconnected, &this.fillPayload,
-            &this.handleStatusCode, &this.handle);
+            &this.connect, &this.disconnected, &this.fillPayload, &this.handle);
         request.run();
     }
 

--- a/relnotes/allnodes.migration.md
+++ b/relnotes/allnodes.migration.md
@@ -1,0 +1,21 @@
+## Client all-nodes / suspendable cores automatically handle supported codes
+
+`swarm.neo.client.mixins.AllNodesRequestCore`,
+`swarm.neo.client.mixins.SuspendableRequestCore`
+
+The `HandleStatusCode` template arguments and the corresponding runtime
+arguments (where apporpriate) have been removed from:
+    * `AllNodesRequestInitialiser`
+    * `createAllNodesRequestInitialiser`
+    * `SuspendableRequestInitialiser`
+    * `createSuspendableRequestInitialiser`
+
+`AllNodesRequestInitialiser` now handles un/supported codes automatically,
+calling the request struct's `handleSupportedCodes` function.
+    
+User code that specifies a status code handler should be adapted as follows:
+    1. Any handling of un/supported codes should be removed.
+    2. Handling of request-specific status codes should be moved into the main
+       request handler function (i.e. the `Handler` policy of
+       `AllNodesRequestCore`).
+

--- a/src/swarm/neo/client/mixins/RequestCore.d
+++ b/src/swarm/neo/client/mixins/RequestCore.d
@@ -388,7 +388,7 @@ public template RequestCore ( RequestType request_type_, ubyte request_code,
 
     /***************************************************************************
 
-        Private helper function to handle notification of the global supported
+        Helper function to handle notification of the global supported
         codes, including the RequestSupported code.
 
         Params:
@@ -403,7 +403,7 @@ public template RequestCore ( RequestType request_type_, ubyte request_code,
 
     ***************************************************************************/
 
-    private static bool handleSupportedCodes ( SupportedStatus status,
+    public static bool handleSupportedCodes ( SupportedStatus status,
         Context* context, AddrPort remote_address )
     {
         switch ( status )


### PR DESCRIPTION
Previously, this behaviour had to be defined by each request, via a policy.

Part of #220.