### PR TITLE
Also register request handler with map in deprecated method

### DIFF
--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -195,6 +195,7 @@ class ConnectionHandler : IConnectionHandler
             ri.handler = handler;
             ri.timing = true;
             this.map[code] = ri;
+            this.supported_requests[code] = true;
         }
 
         /***********************************************************************


### PR DESCRIPTION
The `add` methods of ConnectionHandler.RequestMap were updated in
6c075ca994a506629d12f46910f911304f0efbd0, but the deprecated
`opIndexAssign` was missed.

(Bug fix for unreleased code in v4.x.x.)