### PR TITLE
Use TypeInfo_Class.initializer() in D2 builds to get the initializer

### DIFF
--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -693,12 +693,21 @@ class ConnectionHandler : IConnectionHandler
         assert(!(ci.flags & 8) && ci.defaultConstructor is null);
         assert(ci.destructor is null);
 
+        version (D_Version2)
+        {
+            auto initializer = ci.initializer();
+        }
+        else
+        {
+            auto initializer = ci.init;
+        }
+
         // Allocate space
-        buf.length = ci.init.length;
+        buf.length = initializer.length;
         enableStomping(buf);
 
         // Initialize it
-        buf[] = ci.init[];
+        buf[] = initializer[];
 
         // Cast to T (and check that the cast succeeded)
         auto t_instance = cast(T)cast(Object)buf.ptr;


### PR DESCRIPTION
TypeInfo_Class.init is deprecated and removed from the runtime (since
.init clashes with the type property of the same name). This uses
`initializer()` method which is the new way of accessing the same thing
in D2.

https://github.com/dlang/druntime/pull/1403
https://github.com/dlang/druntime/pull/1766
https://github.com/dlang/druntime/pull/1807

https://issues.dlang.org/show_bug.cgi?id=15037
https://issues.dlang.org/show_bug.cgi?id=12233

(note - this still works with the dmd-transitional, but it breaks with v2.078 in v5.x.x, so fixing it here, as this approach works as well).