### PR TITLE
Remove the ClientStats integration test workaround for oceans < 3.6.0

### DIFF
--- a/integrationtest/client_stats/main.d
+++ b/integrationtest/client_stats/main.d
@@ -2,9 +2,6 @@
 
     Test for registering client stats log with an app's reopenable files ext.
 
-    deprecated code for pre-v3.6.0 ocean can be removed once the ocean submodule
-    is updated.
-
     Copyright:
         Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
 
@@ -40,47 +37,18 @@ else void main ( )
     auto client_stats = new ClientStats(app, new EpollSelectDispatcher,
         "client_stats.log");
 
-    static if ( hasFeaturesFrom!("ocean", 3, 6) )
-    {
-        test(app.rof_ext.reopenFile("client_stats.log"));
-    }
-    else
-    {
-        test!("==")(app.rof_ext.files.length, 1);
-        test!("==")(app.rof_ext.files[0].toString(), "client_stats.log");
-    }
-}
-
-static if ( !hasFeaturesFrom!("ocean", 3, 6) )
-{
-    // Extend ReopenableFilesExt to work around the fact that the list of
-    // registered files is private.
-    class TestReopenableFilesExt : ReopenableFilesExt
-    {
-        File[] files;
-
-        override public void register ( File file )
-        {
-            this.files ~= file;
-            super.register(file);
-        }
-    }
+    test(app.rof_ext.reopenFile("client_stats.log"));
 }
 
 // Simple app class with a reopenable files extension.
 class App : Application
 {
-    static if ( hasFeaturesFrom!("ocean", 3, 6) )
-        alias ReopenableFilesExt ROFExt;
-    else
-        alias TestReopenableFilesExt ROFExt;
-
-    ROFExt rof_ext;
+    ReopenableFilesExt rof_ext;
 
     this ( )
     {
         super("test", "test");
-        this.rof_ext = new ROFExt;
+        this.rof_ext = new ReopenableFilesExt;
         this.registerExtension(this.rof_ext);
     }
 


### PR DESCRIPTION
We can use the feature from the Ocean newer than 3.6.0, as we're
supporting it.

Fixes #252