### PR TITLE
Add round-robin request to protocol test

### DIFF
--- a/integrationtest/neo/client/Client.d
+++ b/integrationtest/neo/client/Client.d
@@ -46,6 +46,7 @@ public class Client
         public import GetAll = integrationtest.neo.client.request.GetAll;
         public import Put = integrationtest.neo.client.request.Put;
         public import DoublePut = integrationtest.neo.client.request.DoublePut;
+        public import RoundRobinPut = integrationtest.neo.client.request.RoundRobinPut;
 
         /***********************************************************************
 
@@ -58,15 +59,17 @@ public class Client
             import integrationtest.neo.client.request.internal.GetAll;
             import integrationtest.neo.client.request.internal.Get;
             import integrationtest.neo.client.request.internal.Put;
+            import integrationtest.neo.client.request.internal.Put;
             import integrationtest.neo.client.request.internal.DoublePut;
+            import integrationtest.neo.client.request.internal.RoundRobinPut;
         }
 
         /// Instantiation of ClientCore.
         mixin ClientCore!();
 
         /// Instantiation of RequestStatsTemplate.
-        alias RequestStatsTemplate!("Put", "DoublePut", "Get", "GetAll")
-            RequestStats;
+        alias RequestStatsTemplate!("Put", "DoublePut", "RoundRobinPut", "Get",
+            "GetAll") RequestStats;
 
         /***********************************************************************
 
@@ -117,6 +120,33 @@ public class Client
             );
 
             this.assign!(Internals.DoublePut)(params);
+        }
+
+        /***********************************************************************
+
+            Assigns a RoundRobinPut request, instructing one node (chosen
+            according to a round-robin sequence) to associate the specified
+            value and key.
+
+            Params:
+                key = key of record to add to node
+                value = value of record to add to node
+                notifier = notifier, called when interesting events occur for
+                    this request
+
+        ***********************************************************************/
+
+        public void roundRobinPut ( hash_t key, in void[] value,
+            RoundRobinPut.Notifier notifier )
+        {
+            auto params = Const!(Internals.RoundRobinPut.UserSpecifiedParams)(
+                Const!(RoundRobinPut.Args)(key, value),
+                Const!(Internals.RoundRobinPut.UserSpecifiedParams.SerializedNotifier)(
+                    *(cast(Const!(ubyte[notifier.sizeof])*)&notifier)
+                )
+            );
+
+            this.assign!(Internals.RoundRobinPut)(params);
         }
 
         /***********************************************************************
@@ -356,6 +386,61 @@ public class Client
             }
 
             this.outer.neo.doublePut(key, value, &internalNotifier);
+            if ( !finished )
+                task.suspend();
+
+            return succeeded;
+        }
+
+        /***********************************************************************
+
+            Assigns a RoundRobinPut request, instructing one node (chosen
+            according to a round-robin sequence) to associate the specified
+            value and key. The calling Task is blocked until the request
+            finishes.
+
+            Params:
+                key = key of record to add to nodes
+                value = value of record to add to nodes
+                notifier = notifier, called when interesting events occur for
+                    this request
+
+            Returns:
+                true if the RoundRobinPut request succeeded on a node, false if
+                it failed on all nodes
+
+        ***********************************************************************/
+
+        public bool roundRobinPut ( hash_t key, in void[] value,
+            Neo.RoundRobinPut.Notifier notifier )
+        {
+            auto task = Task.getThis();
+            assert(task !is null);
+
+            bool succeeded, finished;
+            void internalNotifier ( Neo.RoundRobinPut.Notification info,
+                Neo.RoundRobinPut.Args args )
+            {
+                notifier(info, args);
+
+                switch ( info.active )
+                {
+                    case info.active.succeeded:
+                        succeeded = true;
+                        finished = true;
+                        break;
+                    case info.active.failure:
+                        finished = true;
+                        break;
+                    default:
+                        // Do nothing; other notifications are non-final.
+                }
+
+                if ( finished && task.suspended )
+                    task.resume();
+            }
+
+            this.outer.neo.roundRobinPut(key, value, &internalNotifier);
             if ( !finished )
                 task.suspend();
 

--- a/integrationtest/neo/client/request/RoundRobinPut.d
+++ b/integrationtest/neo/client/request/RoundRobinPut.d
@@ -1,0 +1,77 @@
+/*******************************************************************************
+
+    User-facing API for the client's RoundRobinPut request.
+
+    Puts the specified record to one node, with nodes queried in a round-robin
+    fashion.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.neo.client.request.RoundRobinPut;
+
+import ocean.transition;
+import ocean.core.SmartUnion;
+import swarm.neo.client.NotifierTypes;
+
+/*******************************************************************************
+
+    Request-specific arguments provided by the user and passed to the notifier.
+
+*******************************************************************************/
+
+public struct Args
+{
+    hash_t key;
+    void[] value;
+}
+
+/*******************************************************************************
+
+    Union of possible notifications.
+
+*******************************************************************************/
+
+private union NotificationUnion
+{
+    /// The request succeeded.
+    NoInfo succeeded;
+
+    /// The request was tried on a node and failed due to a connection error;
+    /// it will be retried on any remaining nodes.
+    RequestNodeExceptionInfo node_disconnected;
+
+    /// The request was tried on a node and failed due to an internal node
+    /// error; it will be retried on any remaining nodes.
+    RequestNodeInfo node_error;
+
+    /// The request was tried and failed because it is unsupported.
+
+    /// The request was tried on a node and failed because it is unsupported; it
+    /// will be retried on any remaining nodes.
+    RequestNodeUnsupportedInfo unsupported;
+
+    /// The request tried all nodes and failed.
+    NoInfo failure;
+}
+
+/*******************************************************************************
+
+    Notification smart union.
+
+*******************************************************************************/
+
+public alias SmartUnion!(NotificationUnion) Notification;
+
+/*******************************************************************************
+
+    Type of notifcation delegate.
+
+*******************************************************************************/
+
+public alias void delegate ( Notification, Args ) Notifier;

--- a/integrationtest/neo/client/request/internal/RoundRobinPut.d
+++ b/integrationtest/neo/client/request/internal/RoundRobinPut.d
@@ -1,0 +1,185 @@
+/*******************************************************************************
+
+    Internal implementation of the client's RoundRobinPut request.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.neo.client.request.internal.RoundRobinPut;
+
+import ocean.transition;
+
+/*******************************************************************************
+
+    RoundRobinPut request implementation.
+
+    Note that request structs act simply as namespaces for the collection of
+    symbols required to implement a request. They are never instantiated and
+    have no fields or non-static functions.
+
+    The client expects several things to be present in a request struct:
+        1. The static constants request_type and request_code
+        2. The UserSpecifiedParams struct, containing all user-specified request
+            setup (including a notifier)
+        3. The Notifier delegate type
+        4. Optionally, the Controller type (if the request can be controlled,
+           after it has begun)
+        5. The handler() function
+        6. The all_finished_notifier() function
+
+    The RequestCore mixin provides items 1 and 2.
+
+*******************************************************************************/
+
+public struct RoundRobinPut
+{
+    import integrationtest.neo.common.RoundRobinPut;
+    import integrationtest.neo.client.request.RoundRobinPut;
+    import integrationtest.neo.common.RequestCodes;
+    import swarm.neo.client.mixins.RequestCore;
+    import swarm.neo.client.RequestHandlers : IRoundRobinConnIterator;
+
+    import ocean.io.select.protocol.generic.ErrnoIOException: IOError;
+
+    /***************************************************************************
+
+        Data which the request needs while it is progress. An instance of this
+        struct is stored per connection on which the request runs and is passed
+        to the request handler.
+
+    ***************************************************************************/
+
+    private static struct SharedWorking
+    {
+        /// Did the request succeed on a node?
+        bool succeeded;
+    }
+
+    /***************************************************************************
+
+        Data which each request-on-conn needs while it is progress. An instance
+        of this struct is stored per connection on which the request runs and is
+        passed to the request handler.
+
+    ***************************************************************************/
+
+    private static struct Working
+    {
+        // Dummy (not required by this request)
+    }
+
+    /***************************************************************************
+
+        Request core. Mixes in the types `NotificationInfo`, `Notifier`,
+        `Params`, `Context` plus the static constants `request_type` and
+        `request_code`.
+
+    ***************************************************************************/
+
+    mixin RequestCore!(RequestType.RoundRobin, RequestCode.RoundRobinPut, 0, Args,
+        SharedWorking, Working, Notification);
+
+    /***************************************************************************
+
+        Request handler. Called from RequestOnConn.runHandler().
+
+        Params:
+            conns = round-robin getter for per-connection event dispatchers
+            context_blob = untyped chunk of data containing the serialized
+                context of the request which is to be handled
+            working_blob = untyped chunk of data containing the serialized
+                working data for the request on this connection
+
+    ***************************************************************************/
+
+    public static void handler ( IRoundRobinConnIterator conns,
+        void[] context_blob, void[] working_blob )
+    {
+        auto context = RoundRobinPut.getContext(context_blob);
+        context.shared_working.succeeded = false;
+
+        round_robin: foreach (conn; conns)
+        {
+            try
+            {
+                // Send request info to node
+                conn.send(
+                    ( conn.Payload payload )
+                    {
+                        payload.add(RoundRobinPut.cmd.code);
+                        payload.add(RoundRobinPut.cmd.ver);
+                        payload.add(context.user_params.args.key);
+                        payload.addArray(context.user_params.args.value);
+                    }
+                );
+                conn.flush();
+
+                // Receive supported status from node
+                auto supported = conn.receiveValue!(SupportedStatus)();
+                if ( RoundRobinPut.handleSupportedCodes(supported, context,
+                    conn.remote_address) )
+                {
+                    // Receive result message from node
+                    auto result = conn.receiveValue!(MessageType)();
+                    with ( MessageType ) switch ( result )
+                    {
+                        case Succeeded:
+                            context.shared_working.succeeded = true;
+                            break round_robin;
+
+                        case Error:
+                            // The node returned an error code. Notify the user.
+                            Notification n;
+                            n.node_error = RequestNodeInfo(
+                                context.request_id, conn.remote_address);
+                            RoundRobinPut.notify(context.user_params, n);
+                            break;
+
+                        default:
+                            // Treat unknown codes as internal errors.
+                            goto case Error;
+                    }
+                }
+            }
+            catch ( IOError e )
+            {
+                // A connection error occurred. Notify the user.
+                Notification n;
+                n.node_disconnected = RequestNodeExceptionInfo(
+                    context.request_id, conn.remote_address, e);
+                RoundRobinPut.notify(context.user_params, n);
+            }
+        }
+    }
+
+    /***************************************************************************
+
+        Request finished notifier. Called from Request.handlerFinished().
+
+        Params:
+            context_blob = untyped chunk of data containing the serialized
+                context of the request which is finishing
+            working_data_iter = iterator over the stored working data associated
+                with each connection on which this request was run
+
+    ***************************************************************************/
+
+    public static void all_finished_notifier ( void[] context_blob,
+        IRequestWorkingData working_data_iter )
+    {
+        auto context = RoundRobinPut.getContext(context_blob);
+        Notification n;
+
+        if ( context.shared_working.succeeded )
+            n.succeeded = NoInfo();
+        else
+            n.failure = NoInfo();
+
+        RoundRobinPut.notify(context.user_params, n);
+    }
+}

--- a/integrationtest/neo/common/RequestCodes.d
+++ b/integrationtest/neo/common/RequestCodes.d
@@ -18,5 +18,6 @@ public enum RequestCode : ubyte
     Put,
     Get,
     GetAll,
-    DoublePut
+    DoublePut,
+    RoundRobinPut
 }

--- a/integrationtest/neo/common/RoundRobinPut.d
+++ b/integrationtest/neo/common/RoundRobinPut.d
@@ -1,0 +1,27 @@
+/*******************************************************************************
+
+    Common protocol definitions for the RoundRobinPut request.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.neo.common.RoundRobinPut;
+
+/*******************************************************************************
+
+    Message type enum. Sent from the node to the client.
+
+*******************************************************************************/
+
+public enum MessageType : ubyte
+{
+    None,       // Invalid, default value
+
+    Succeeded,  // Value written
+    Error       // Internal node error occurred
+}

--- a/integrationtest/neo/main.d
+++ b/integrationtest/neo/main.d
@@ -77,6 +77,7 @@ class Test : Task
         this.testPutGetAllSuspend();
         this.testSerialize();
         this.testSerializeVersioned();
+        this.testRoundRobinPut();
         this.testDisconnect();
         this.testDoublePut();
 
@@ -430,6 +431,21 @@ class Test : Task
         enforce!("!is")(record.ptr, null);
         enforce!("==")(record.ptr.name, "Bob");
         enforce!("==")(record.ptr.age, 23);
+    }
+
+    /***************************************************************************
+
+        Runs a simple test where a second node is added to the client's registry
+        and a single record is written to a node with RoundRobinPut.
+
+    ***************************************************************************/
+
+    private void testRoundRobinPut ( )
+    {
+        auto ok = this.client.blocking.roundRobinPut(23, "hello",
+            ( Client.Neo.RoundRobinPut.Notification info,
+                Client.Neo.RoundRobinPut.Args args ) { });
+        enforce(ok, "RoundRobinPut request failed");
     }
 
     /***************************************************************************

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -38,6 +38,7 @@ public class Node : NodeBase!(ConnHandler)
     import integrationtest.neo.node.request.GetAll;
     import integrationtest.neo.node.request.Put;
     import integrationtest.neo.node.request.DoublePut;
+    import integrationtest.neo.node.request.RoundRobinPut;
 
     /***************************************************************************
 
@@ -72,6 +73,8 @@ public class Node : NodeBase!(ConnHandler)
             "Put", PutImpl_v0.classinfo);
         options.requests.add(Command(RequestCode.DoublePut, 0),
             "DoublePut", DoublePutImpl_v0.classinfo);
+        options.requests.add(Command(RequestCode.RoundRobinPut, 0),
+            "RoundRobinPut", RoundRobinPutImpl_v0.classinfo);
 
         options.credentials_map["dummy"] = Key.init;
         options.shared_resources = this.shared_resources;

--- a/integrationtest/neo/node/request/RoundRobinPut.d
+++ b/integrationtest/neo/node/request/RoundRobinPut.d
@@ -1,0 +1,82 @@
+/*******************************************************************************
+
+    Internal implementation of the node's RoundRobinPut request.
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module integrationtest.neo.node.request.RoundRobinPut;
+
+import ocean.transition;
+import integrationtest.neo.node.Storage;
+import swarm.neo.node.RequestOnConn;
+import swarm.neo.request.Command;
+import swarm.neo.node.IRequestHandler;
+
+/*******************************************************************************
+
+    Implementation of the v0 RoundRobinPut request protocol.
+
+*******************************************************************************/
+
+public class RoundRobinPutImpl_v0 : IRequestHandler
+{
+    import integrationtest.neo.common.RoundRobinPut;
+    import integrationtest.neo.node.request.mixins.RequestCore;
+
+    mixin RequestCore!();
+
+    /***************************************************************************
+
+        Called by the connection handler immediately after the request code and
+        version have been parsed from a message received over the connection.
+        Allows the request handler to process the remainder of the incoming
+        message, before the connection handler sends the supported code back to
+        the client.
+
+        Note: the initial payload is a slice of the connection's read buffer.
+        This means that when the request-on-conn fiber suspends, the contents of
+        the buffer (hence the slice) may change. It is thus *absolutely
+        essential* that this method does not suspend the fiber. (This precludes
+        all I/O operations on the connection.)
+
+        Params:
+            init_payload = initial message payload read from the connection
+
+    ***************************************************************************/
+
+    public void preSupportedCodeSent ( Const!(void)[] init_payload )
+    {
+        auto parser = this.connection.event_dispatcher.message_parser;
+
+        hash_t key;
+        cstring value;
+        parser.parseBody(init_payload, key, value);
+
+        this.storage.map[key] = value.dup;
+    }
+
+    /***************************************************************************
+
+        Called by the connection handler after the supported code has been sent
+        back to the client.
+
+    ***************************************************************************/
+
+    public void postSupportedCodeSent ( )
+    {
+        auto ed = this.connection.event_dispatcher;
+        ed.send(
+            ( ed.Payload payload )
+            {
+                payload.addCopy(MessageType.Succeeded);
+            }
+        );
+        ed.flush();
+    }
+}


### PR DESCRIPTION
Previously, the round-robin code was not being compiled, due to templates.
This simple addition to the protocol test ensures that this code is
compiled and tested.

Fixes #263.