### PR TITLE
Add `AddrPort.getAddress` to v4.7

### DIFF
--- a/relnotes/inet_ntop.feature.md
+++ b/relnotes/inet_ntop.feature.md
@@ -1,0 +1,6 @@
+### Obtain the address in `AddrPort` as a dotted-decimal string
+
+`swarm.neo.AddrPort`
+
+A new method `getAddress` has been added, which converts the current address,
+i.e. `AddrPort.naddress`, to a dotted-decimal string.


### PR DESCRIPTION
Replaces #277, new PR needed after changing the base for Travis tests to run.

This method writes the current IP address to a string in the well-known
IPv4 dotted-decimal notation.