### PR TITLE
Add missing import + `Controllers` template test

### DIFF
--- a/src/swarm/neo/client/RequestOnConnSet.d
+++ b/src/swarm/neo/client/RequestOnConnSet.d
@@ -38,7 +38,7 @@ public struct RequestOnConnSet
     }
 
     /// Type of request currently using this instance.
-    private enum RequestType
+    public enum RequestType
     {
         None,
         SingleNode, // Includes round-robin requests.

--- a/src/swarm/neo/client/mixins/Controllers.d
+++ b/src/swarm/neo/client/mixins/Controllers.d
@@ -168,6 +168,8 @@ template Controllers ( )
     public class Suspendable ( ControllerInterface ) :
         Controller!(ControllerInterface), ISuspendable
     {
+        import ocean.core.Verify;
+
         /***********************************************************************
 
             Enum of possible pending state-changes.
@@ -322,4 +324,22 @@ template Controllers ( )
                 ~ "by " ~ typeof(this).stringof);
         }
     }
+}
+
+/// Unit test instantiating the templates to detect semantic errors
+version (UnitTest) private class ControllersTemplateTest
+{
+    import swarm.neo.protocol.Message: RequestId;
+
+    interface DummyControllerInterface
+    {
+        bool suspend();
+        bool resume();
+    }
+
+    abstract bool control(RequestId, void delegate(DummyControllerInterface));
+
+    mixin Controllers!();
+    class C: Controller!(DummyControllerInterface) {}
+    class S: Suspendable!(DummyControllerInterface) {}
 }


### PR DESCRIPTION
DMD v2.078 reported a missing import for `verify` when compiling dmqproto.