### PR TITLE
Deprecate TCP_CORK based flush.

### DIFF
--- a/integrationtest/neo/client/request/internal/DoublePut.d
+++ b/integrationtest/neo/client/request/internal/DoublePut.d
@@ -165,7 +165,6 @@ public struct DoublePut
                             payload.addArray(context.user_params.args.value);
                         }
                     );
-                    conn.flush();
 
                     // Receive supported status from node
                     auto supported = conn.receiveValue!(SupportedStatus)();

--- a/integrationtest/neo/client/request/internal/Get.d
+++ b/integrationtest/neo/client/request/internal/Get.d
@@ -145,7 +145,6 @@ public struct VersionedGet ( ubyte Version )
                             payload.add(context.user_params.args.key);
                         }
                     );
-                    conn.flush();
 
                     // Receive supported status from node
                     auto supported = conn.receiveValue!(SupportedStatus)();

--- a/integrationtest/neo/client/request/internal/GetAll.d
+++ b/integrationtest/neo/client/request/internal/GetAll.d
@@ -380,7 +380,6 @@ private struct Reader
                                 payload.addCopy(MessageType.Ack);
                             }
                         );
-                        this.conn.flush();
                     }
                     break;
 

--- a/integrationtest/neo/client/request/internal/Put.d
+++ b/integrationtest/neo/client/request/internal/Put.d
@@ -136,7 +136,6 @@ public struct Put
                             payload.addArray(context.user_params.args.value);
                         }
                     );
-                    conn.flush();
 
                     // Receive supported status from node
                     auto supported = conn.receiveValue!(SupportedStatus)();

--- a/integrationtest/neo/client/request/internal/RoundRobinPut.d
+++ b/integrationtest/neo/client/request/internal/RoundRobinPut.d
@@ -117,7 +117,6 @@ public struct RoundRobinPut
                         payload.addArray(context.user_params.args.value);
                     }
                 );
-                conn.flush();
 
                 // Receive supported status from node
                 auto supported = conn.receiveValue!(SupportedStatus)();

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -64,6 +64,7 @@ public class Node : NodeBase!(ConnHandler)
 
         Options options;
         options.epoll = epoll;
+        options.no_delay = true;
 
         options.requests.add(Command(RequestCode.Get, 0),
             "Get", GetImpl_v0.classinfo);

--- a/integrationtest/neo/node/request/DoublePut.d
+++ b/integrationtest/neo/node/request/DoublePut.d
@@ -77,6 +77,5 @@ public class DoublePutImpl_v0 : IRequestHandler
                 payload.addCopy(RequestStatusCode.Succeeded);
             }
         );
-        ed.flush();
     }
 }

--- a/integrationtest/neo/node/request/Get.d
+++ b/integrationtest/neo/node/request/Get.d
@@ -96,6 +96,5 @@ public class GetImpl_v0 : IRequestHandler
                 }
             );
         }
-        ed.flush();
     }
 }

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -84,7 +84,6 @@ public class GetAllImpl_v0 : IRequestHandler
                     payload.addCopy(MessageType.End);
                 }
             );
-            this.outer.connection.event_dispatcher.flush();
 
             this.outer.request_event_dispatcher.receive(this.fiber,
                 Message(MessageType.Ack));
@@ -129,7 +128,6 @@ public class GetAllImpl_v0 : IRequestHandler
                         payload.addCopy(MessageType.Ack);
                     }
                 );
-                this.outer.connection.event_dispatcher.flush();
 
                 // Carry out the specified control message.
                 with ( MessageType ) switch ( message.type )

--- a/integrationtest/neo/node/request/Put.d
+++ b/integrationtest/neo/node/request/Put.d
@@ -77,6 +77,5 @@ public class PutImpl_v0 : IRequestHandler
                 payload.addCopy(RequestStatusCode.Succeeded);
             }
         );
-        ed.flush();
     }
 }

--- a/integrationtest/neo/node/request/RoundRobinPut.d
+++ b/integrationtest/neo/node/request/RoundRobinPut.d
@@ -77,6 +77,5 @@ public class RoundRobinPutImpl_v0 : IRequestHandler
                 payload.addCopy(MessageType.Succeeded);
             }
         );
-        ed.flush();
     }
 }

--- a/relnotes/flush.deprecated.md
+++ b/relnotes/flush.deprecated.md
@@ -1,0 +1,20 @@
+### TCP_CORK based flush is deprecated
+
+`swarm.neo.connection.ConnectionBase`, `swarm.neo.connection.RequestOnConnBase`,
+`swarm.neo.protocol.socket.MessageSender`
+
+The existing `flush` method relied on the TCP_CORK being set and it would then
+pull out and put the cork back in.  However this doesn't work, because putting
+the cork back in had to be done after all the packets are actually sent,
+otherwise the last incomplete packet will be delayed for the 200ms. Since we
+moved to the explicit application buffering for the large data and to the
+explicit flushing for the control messages this flush was deprecated.
+
+The steps to do instead of explicit flush differ on the client and the node side.
+On the client side, the method ClientCore.enableNoDelay() should be called in
+the client's constructor, and on the node side, passing `Options.no_delay` set to
+true in the `NeoNode`'s constructor will suffice to turn on the `TCP_NODELAY`.
+Then, all the implicit batching in the requests should be mitigated to the explicit
+batching (like preparing batches and sending them) and the explicit flushing after
+sending small quick control messages should be removed, as TCP_NODELAY will send
+the message as soon as it's written.

--- a/src/swarm/neo/client/mixins/AllNodesRequestCore.d
+++ b/src/swarm/neo/client/mixins/AllNodesRequestCore.d
@@ -404,7 +404,6 @@ public struct AllNodesRequestInitialiser ( Request, FillPayload,
                 this.fill_payload(payload);
             }
         );
-        this.conn.flush();
 
         // Receive status from node and stop the request if not Ok
         auto status = conn.receiveValue!(ubyte)();

--- a/src/swarm/neo/client/mixins/SuspendableRequestCore.d
+++ b/src/swarm/neo/client/mixins/SuspendableRequestCore.d
@@ -812,7 +812,6 @@ public struct SuspendableRequestControllerFiber ( Request, MessageType )
                 payload.add(msg);
             }
         );
-        this.conn.flush();
 
         // Wait for ACK.
         this.request_event_dispatcher.receive(this.fiber,

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -125,6 +125,7 @@ abstract class ConnectionBase: ISelectClient
 
         ***********************************************************************/
 
+        deprecated("Use TCP_NODELAY and explicit buffering instead.")
         public bool flush_requested;
 
         /***********************************************************************
@@ -433,8 +434,6 @@ abstract class ConnectionBase: ISelectClient
                 // Register the socket for both input and output
                 this.outer.registerEpoll(true);
                 this.outer.sender.finishSending(this.suspend());
-                if (this.flush_requested)
-                    this.outer.sender.flush();
             }
         }
     }
@@ -1208,6 +1207,7 @@ abstract class ConnectionBase: ISelectClient
 
     ***************************************************************************/
 
+    deprecated("Use TCP_NODELAY and explicit buffering instead.")
     public void flush ( )
     {
         // Flush the OS-maintained (TCP_CORK) socket output buffer. This will

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -784,6 +784,7 @@ abstract class RequestOnConnBase
 
         ***********************************************************************/
 
+        deprecated("Use TCP_NODELAY and explicit buffering instead.")
         public void flush ( )
         {
             this.outer.connection.flush();

--- a/src/swarm/neo/protocol/connect/ConnectProtocol.d
+++ b/src/swarm/neo/protocol/connect/ConnectProtocol.d
@@ -284,8 +284,6 @@ class ConnectProtocol: ISelectClient
             this.registerEpoll(Event.EPOLLOUT);
             this.sender.finishSending(this.wait());
         }
-
-        this.sender.flush();
     }
 
     /***************************************************************************

--- a/src/swarm/neo/protocol/socket/MessageSender.d
+++ b/src/swarm/neo/protocol/socket/MessageSender.d
@@ -5,6 +5,18 @@
     This class is suitable for both half and full duplex because it does not
     handle epoll notifications directly (it is not a select client).
 
+    Once upon a time there was an explicit flush method. It relied on the
+    TCP_CORK being set and it would then pull out and put the cork back in.
+    However this wouldn't work, because putting the cork back in had to be done
+    after all the packets are actually sent, otherwise the last incomplete packet
+    would be delayed for the 200ms. Since we moved to the explicit application
+    buffering for the large data and to the explicit flushing for the control
+    messages this flush was deprecated. If there's a need to bring it in again,
+    instead of TCP_CORK on/off, what it should do is to set the TCP_NODELAY
+    on (which is overridden by TCP_CORK, but still forces explicit flush of all
+    pending data). See https://github.com/sociomantic-tsunami/dmqproto/issues/48
+    for more info.
+
     Copyright: Copyright (c) 2010-2017 sociomantic labs GmbH. All rights reserved
 
     License:
@@ -225,6 +237,7 @@ class MessageSender
 
     ***************************************************************************/
 
+    deprecated("Use TCP_NODELAY and explicit buffering instead.")
     public void flush ( )
     {
         if (this.cork_)


### PR DESCRIPTION
The existing `flush` method relied on the TCP_CORK being set and it would then
pull out and put the cork back in.  However this doesn't work, because putting
the cork back in had to be done after all the packets are actually sent,
otherwise the last incomplete packet will be delayed for the 200ms. Since we
moved to the explicit application buffering for the large data and to the
explicit flushing for the control messages this flush was deprecated.

See sociomantic-tsunami/dmqproto#48