### PR TITLE
Change `EventDispatcher.shutdownWithProtocolError` to throw, not return

### DIFF
--- a/relnotes/shutdownwithprotocolerror.migration.md
+++ b/relnotes/shutdownwithprotocolerror.migration.md
@@ -1,0 +1,9 @@
+### `EventDispatcher.shutdownWithProtocolError` now throws instead of returning
+
+`swarm.neo.connection.RequestOnConnBase`
+
+The method `EventDispatcher.shutdownWithProtocolError` used to return an
+exception with the expectation that the caller will throw it. The behaviour has
+now changed such that `EventDispatcher.shutdownWithProtocolError` throws this
+exception directly. This simplifies usage of the method.
+

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -511,24 +511,23 @@ abstract class RequestOnConnBase
             Initiates a connection shutdown from inside the fiber, throwing an
             exception of type ProtocolError in all other requests that are
             currently using this connection or attempt to use it, until the
-            shutdown is complete. The exception instance is then returned -- the
-            caller is expected to throw it in the context of the request handler
-            that called this method.
+            shutdown is complete. The exception instance is then thrown, killing
+            the request handler that called this method.
 
             Params:
                 e = the exception reflecting the reason for the shutdown
 
-            Returns:
+            Throws:
                 The ProtocolError that was used to shut down the connection
 
         ***********************************************************************/
 
-        public ProtocolError shutdownWithProtocolError ( cstring msg,
+        public void shutdownWithProtocolError ( cstring msg,
             istring file = __FILE__, int line = __LINE__ )
         {
             auto e = this.outer.connection.protocol_error.set(msg, file, line);
             this.shutdownConnection(e);
-            return e;
+            throw e;
         }
 
         /***********************************************************************

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -481,7 +481,7 @@ class ConnectionHandler : IConnectionHandler
         }
         else
         {
-            throw connection.event_dispatcher.shutdownWithProtocolError(
+            connection.event_dispatcher.shutdownWithProtocolError(
                 "First request message contains no command"
             );
         }

--- a/src/swarm/neo/request/RequestEventDispatcher.d
+++ b/src/swarm/neo/request/RequestEventDispatcher.d
@@ -889,7 +889,7 @@ public struct RequestEventDispatcher
             }
         }
 
-        throw conn.shutdownWithProtocolError("Unhandled signal code");
+        conn.shutdownWithProtocolError("Unhandled signal code");
     }
 
     /***************************************************************************
@@ -928,7 +928,7 @@ public struct RequestEventDispatcher
             }
         }
 
-        throw conn.shutdownWithProtocolError("Unhandled message");
+        conn.shutdownWithProtocolError("Unhandled message");
     }
 
     /***************************************************************************
@@ -964,7 +964,7 @@ public struct RequestEventDispatcher
         }
 
         if ( this.waiting_fibers_to_iterate.length == 0 )
-            throw conn.shutdownWithProtocolError("Unhandled resume after yield");
+            conn.shutdownWithProtocolError("Unhandled resume after yield");
 
         foreach ( fiber_to_notify; this.waiting_fibers_to_iterate.array() )
         {


### PR DESCRIPTION
The returned exception is intended to always be thrown, and it would be a
bug, really, if the caller did not do so. Therefore, making the method
throw directly simplifies usage and removes one vector for bugs.