### PR TITLE
Use ocean.transitional.gc_usage

### DIFF
--- a/src/swarm/node/connection/ConnectionHandler.d
+++ b/src/swarm/node/connection/ConnectionHandler.d
@@ -279,12 +279,12 @@ public abstract class ConnectionHandlerTemplate ( Commands : ICommandCodes )
         {
             const float Mb = 1024 * 1024;
             size_t used1, free1;
-            GC.usage(used1, free1);
+            gc_usage(used1, free1);
 
             scope ( exit )
             {
                 size_t used2, free2;
-                GC.usage(used2, free2);
+                gc_usage(used2, free2);
 
                 if ( used2 > used1 )
                 {


### PR DESCRIPTION
GC.usage is deprecated (and removed newer DMDs) with the GC.stats
replacement in druntime and backward and forward compatible wrapper in
ocean.transitional.gc_usage.
