### PR TITLE
Set TCP_NODELAY on for both client and server side

### DIFF
--- a/integrationtest/neo/client/Client.d
+++ b/integrationtest/neo/client/Client.d
@@ -632,7 +632,6 @@ public class Client
         ubyte[] auth_key = Key.init.content;
         this.neo = new Neo(auth_name, auth_key,
             Neo.Settings(this.conn_notifier));
-        this.neo.enableSocketNoDelay();
         this.neo.addNode(addr, port);
 
         this.blocking = new Blocking;
@@ -656,7 +655,6 @@ public class Client
         this.conn_notifier = conn_notifier;
 
         this.neo = new Neo(config, Neo.Settings(this.conn_notifier));
-        this.neo.enableSocketNoDelay();
 
         this.blocking = new Blocking;
     }

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -64,7 +64,6 @@ public class Node : NodeBase!(ConnHandler)
 
         Options options;
         options.epoll = epoll;
-        options.no_delay = true;
 
         options.requests.add(Command(RequestCode.Get, 0),
             "Get", GetImpl_v0.classinfo);

--- a/relnotes/flush.deprecated.md
+++ b/relnotes/flush.deprecated.md
@@ -10,11 +10,10 @@ otherwise the last incomplete packet will be delayed for the 200ms. Since we
 moved to the explicit application buffering for the large data and to the
 explicit flushing for the control messages this flush was deprecated.
 
-The steps to do instead of explicit flush differ on the client and the node side.
-On the client side, the method ClientCore.enableNoDelay() should be called in
-the client's constructor, and on the node side, passing `Options.no_delay` set to
-true in the `NeoNode`'s constructor will suffice to turn on the `TCP_NODELAY`.
-Then, all the implicit batching in the requests should be mitigated to the explicit
+Since now the TCP_NODELAY is always on, `ClientCore.enableNoDelay` and
+`NeoNode.Options.no_delay` are now also deprecated and do nothing.
+
+All the implicit batching in the requests should be mitigated to the explicit
 batching (like preparing batches and sending them) and the explicit flushing after
 sending small quick control messages should be removed, as TCP_NODELAY will send
 the message as soon as it's written.

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -219,20 +219,15 @@ public final class Connection: ConnectionBase
             credentials  = authentication credentials
             request_set  = the request set
             epoll        = epoll select dispatcher
-            no_delay     = if false, data written to the socket will be buffered
-                and sent according to Nagle's algorithm and TCP Cork. If true,
-                no buffering will occur. (The no-delay option is not generally
-                suited to live servers, where efficient packing of packets is
-                desired, but can be useful for low-bandwidth test setups.)
 
     ***************************************************************************/
 
     public this ( Const!(Credentials) credentials, IRequestSet request_set,
-                  EpollSelectDispatcher epoll, bool no_delay = false )
+                  EpollSelectDispatcher epoll )
     {
         this.client_socket = new ClientSocket;
 
-        super(this.client_socket.socket, epoll, no_delay);
+        super(this.client_socket.socket, epoll);
 
         this.conn_init = new ClientConnect(credentials);
         this.request_set = request_set;

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -47,13 +47,14 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
 
         Set this flag to `true` before calling `start` to prevent TCP socket
         output data buffering through Nagle's algorithm and TCP Cork.
-        Warning: This is meant to be used only in tests which perform sequential
-        requests. For a high data throughput rate it may impact performance so
-        do not use it in a production environment.
+        Warning: Since no buffering is done, in case of many write calls for
+        small amount of data, this may impact performance, since lots of small
+        packets will be generated. It is hence important to coalesce writes that
+        logically belong together into smaller number of writes.
 
     ***************************************************************************/
 
-    public bool socket_no_delay = false;
+    public bool socket_no_delay = true;
 
     /***************************************************************************
 

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -45,19 +45,6 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
 
     /***************************************************************************
 
-        Set this flag to `true` before calling `start` to prevent TCP socket
-        output data buffering through Nagle's algorithm and TCP Cork.
-        Warning: Since no buffering is done, in case of many write calls for
-        small amount of data, this may impact performance, since lots of small
-        packets will be generated. It is hence important to coalesce writes that
-        logically belong together into smaller number of writes.
-
-    ***************************************************************************/
-
-    public bool socket_no_delay = true;
-
-    /***************************************************************************
-
         Registry of connections.
 
     ***************************************************************************/
@@ -298,8 +285,7 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
         bool added;
         auto connection = this.connections.put(node_address, added,
             this.connection_pool.get(new Connection(
-                this.credentials, this.request_set_, this.epoll,
-                this.socket_no_delay
+                this.credentials, this.request_set_, this.epoll
             ))
         );
 

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -972,6 +972,7 @@ template ClientCore ( )
 
     ***************************************************************************/
 
+    deprecated("This is now on by default, simply remove this call")
     public void enableSocketNoDelay ( )
     {
         this.connections.socket_no_delay = true;

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -972,10 +972,9 @@ template ClientCore ( )
 
     ***************************************************************************/
 
-    deprecated("This is now on by default, simply remove this call")
+    deprecated("TCP_NODELAY is now on, this method does nothing.")
     public void enableSocketNoDelay ( )
     {
-        this.connections.socket_no_delay = true;
     }
 }
 

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -119,17 +119,6 @@ abstract class ConnectionBase: ISelectClient
 
         /***********************************************************************
 
-            If this flag is true and `sendRequestPayload` is waiting for
-            `EPOLLOUT` then it will call `sender.flush` after it has sent the
-            remaining data.
-
-        ***********************************************************************/
-
-        deprecated("Use TCP_NODELAY and explicit buffering instead.")
-        public bool flush_requested;
-
-        /***********************************************************************
-
             The queue of ids of requests waiting to send a message.
 
         ***********************************************************************/
@@ -307,11 +296,8 @@ abstract class ConnectionBase: ISelectClient
 
                 try
                 {
-                    if (this.outer.no_delay)
-                        this.outer.socket.setsockoptVal(IPPROTO_TCP,
-                            socket.TcpOptions.TCP_NODELAY, true);
-                    else
-                        this.outer.sender.cork = true;
+                    this.outer.socket.setsockoptVal(IPPROTO_TCP,
+                        socket.TcpOptions.TCP_NODELAY, true);
 
                     // Start the receive fiber, it will suspend itself immediately.
                     this.outer.recv_loop.start();
@@ -766,13 +752,10 @@ abstract class ConnectionBase: ISelectClient
         Params:
             socket       = node/client connection socket
             epoll        = epoll select dispatcher for registering the socket
-            no_delay     = disables TCP socket output buffering (see comments on
-                           the no_delay field, above)
 
     ***************************************************************************/
 
-    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll,
-        bool no_delay = false )
+    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll )
     {
         this.socket               = socket;
         this.epoll                = epoll;
@@ -1205,19 +1188,9 @@ abstract class ConnectionBase: ISelectClient
 
     ***************************************************************************/
 
-    deprecated("Use TCP_NODELAY and explicit buffering instead.")
+    deprecated("TCP_NODELAY is now on by default and this method does nothing")
     public void flush ( )
     {
-        // Flush the OS-maintained (TCP_CORK) socket output buffer. This will
-        // immediately send all data that have been accepted by `sendmsg(2)`.
-        this.sender.flush();
-        // `this.sender` may in addition buffer data that have not been accepted
-        // by `sendmsg` - that is, `send(2)` returned a value less than the
-        // buffer length argument - and wait for `EPOLLOUT` on the socket to
-        // call `sendmsg` again  with the remaining data. Set a flag to flush
-        // the OS-maintained (TCP_CORK) socket output buffer when `sendmsg`
-        // eventually accepted all outstanding data.
-        this.send_loop.flush_requested = true;
     }
 
     /***************************************************************************

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -416,8 +416,6 @@ abstract class ConnectionBase: ISelectClient
         {
             bool finish_sending = false;
 
-            scope (exit) this.flush_requested = false;
-
             this.outer.getPayloadForSending(
                 id,
                 ( in void[][] payload )

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -90,11 +90,6 @@ class Connection: ConnectionBase
             request_pool = global pool of `Request` objects shared across
                            multiple instances of this class
             task_resumer = global resumer to resume yielded `RequestOnConn`s
-            no_delay = if false, data written to the socket will be buffered and
-                sent according to Nagle's algorithm and TCP Cork. If true, no
-                buffering will occur. (The no-delay option is not generally
-                suited to live servers, where efficient packing of packets is
-                desired, but can be useful for low-bandwidth test setups.)
 
     ***************************************************************************/
 
@@ -102,9 +97,9 @@ class Connection: ConnectionBase
                   AddressIPSocket!() socket, EpollSelectDispatcher epoll,
                   RequestSet.Handler request_handler,
                   void delegate ( ) when_closed, RequestPool request_pool,
-                  YieldedRequestOnConns task_resumer, bool no_delay = false )
+                  YieldedRequestOnConns task_resumer )
     {
-        super(socket, epoll, no_delay);
+        super(socket, epoll);
         this.request_set = new RequestSet(this, request_pool, task_resumer, request_handler);
         this.conn_init = new NodeConnect(credentials);
         this.when_closed = when_closed;

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -428,8 +428,7 @@ class ConnectionHandler : IConnectionHandler
         this.connection = new Connection(
             *shared_params.credentials, socket, shared_params.epoll,
             &this.handleRequest, &this.whenConnectionClosed,
-            shared_params.request_pool, shared_params.yielded_rqonconns,
-            shared_params.no_delay
+            shared_params.request_pool, shared_params.yielded_rqonconns
         );
         this.return_to_pool = return_to_pool;
         this.shared_params = shared_params;

--- a/src/swarm/neo/protocol/socket/MessageSender.d
+++ b/src/swarm/neo/protocol/socket/MessageSender.d
@@ -70,14 +70,6 @@ class MessageSender
 
     /***************************************************************************
 
-        true if the TCP Cork feature is currently enabled or false otherwise.
-
-    ***************************************************************************/
-
-    private bool cork_ = false;
-
-    /***************************************************************************
-
         The socket to write to.
 
     ***************************************************************************/
@@ -223,72 +215,6 @@ class MessageSender
         do
             this.io_stats.num_iowait_calls++;
         while (!this.write(src, wait));
-    }
-
-    /***************************************************************************
-
-        Flushes the TCP Cork buffer.
-
-        Note that apart from TCP Cork no output data buffering is done in this
-        class: All sending methods return only after write() accepted all output
-        data. If TCP Cork is enabled then write() may do internal buffering of
-        the payload of one TCP frame; that buffer is flushed after 200 ms.
-        See man 7 tcp.
-
-    ***************************************************************************/
-
-    deprecated("Use TCP_NODELAY and explicit buffering instead.")
-    public void flush ( )
-    {
-        if (this.cork_)
-        {
-            this.cork = false;
-            this.cork = true;
-        }
-    }
-
-    /***************************************************************************
-
-        Enables or disables the TCP Cork feature.
-
-        TCP Cork is a Linux feature to buffer output data for a TCP/IP
-        connection until a full TCP frame (network packet) can be sent. It uses
-        a timeout of 200ms. See man 7 tcp.
-
-        No further output data buffering is done in this class: All sending
-        methods return only after write() accepted all output data.
-
-        Params:
-            enabled = true: enable the TCP Cork option; false: disable it.
-                      Disabling sends all pending data immediately.
-
-        Returns:
-            enable
-
-        Throws:
-            IOException on error setting the TCP Cork option.
-
-    ***************************************************************************/
-
-    public bool cork ( bool enable )
-    {
-        this.error_e.enforce(!this.socket.setsockoptVal(IPPROTO_TCP, TCP_CORK, enable), "unable to set TCP_CORK");
-        this.cork_ = enable;
-        return this.cork_;
-    }
-
-    /**************************************************************************
-
-        Tells whether TCP Cork feature is currently enabled.
-
-        Returns:
-            true if TCP Cork is currently enabled or false otherwise.
-
-     **************************************************************************/
-
-    public bool cork ( )
-    {
-        return this.cork_;
     }
 
     /***************************************************************************

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -676,12 +676,9 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
             Flag controlling whether Nagle's algorithm is disabled (true) or
             left enabled (false) on the underlying socket.
 
-            (The no-delay option is not generally suited to live servers, where
-            efficient packing of packets is desired, but can be useful for
-            low-bandwidth test setups.)
-
         ***********************************************************************/
 
+        deprecated("This field now doesn't affect anything, since TCP_NODELAY is always on")
         public bool no_delay;
 
         /***********************************************************************
@@ -805,10 +802,12 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
             credentials = &s.cred;
         }
 
+        auto no_delay = true;
+
         // Instantiate params object shared by all neo connection handlers.
         auto neo_conn_setup_params = new Neo.ConnectionHandler.SharedParams(
             options.epoll, options.shared_resources, options.requests,
-            options.no_delay, *credentials, this, &this.getResourceAcquirer);
+            no_delay, *credentials, this, &this.getResourceAcquirer);
 
         // Set up unix listener socket, if specified.
         UnixListener unix_listener;


### PR DESCRIPTION
Since the TCP_CORK flush is now deprecated and request implementations
should use explicit buffering, TCP_NODELAY is now always on.

Fixes #296