### PR TITLE
Remove unused import for core.memory that was causing gc_usage clash

### DIFF
--- a/src/swarm/node/connection/ConnectionHandler.d
+++ b/src/swarm/node/connection/ConnectionHandler.d
@@ -79,8 +79,6 @@ import IPSocket = ocean.sys.socket.IPSocket;
 
 import core.sys.posix.netinet.in_: SOL_SOCKET, IPPROTO_TCP, SO_KEEPALIVE;
 
-import core.memory;
-
 debug ( ConnectionHandler ) import ocean.io.Stdout;
 
 import ocean.core.Traits : isArrayType;


### PR DESCRIPTION
gc_usage is defined in both ocean.transition and core.memory, and we're
using the former. This commit removes import to core.memory to prevent
clashes on the symbol with the same name.