### PR TITLE
 Throw on received message if the RoC of an all-nodes request has finished

### DIFF
--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -602,7 +602,8 @@ public final class Connection: ConnectionBase
     {
         if (auto request = this.request_set.getRequest(id))
         {
-            return request.getRequestOnConnForNode(this.node_address);
+            return request.getRequestOnConnForNode(this.node_address,
+                this.protocol_error_);
         }
         else
         {

--- a/src/swarm/neo/client/IRequestSet.d
+++ b/src/swarm/neo/client/IRequestSet.d
@@ -48,7 +48,8 @@ interface IRequest
         FinishedNotifier;
 
     import swarm.neo.AddrPort;
-    IRequestOnConn getRequestOnConnForNode ( AddrPort node_address );
+    import swarm.neo.protocol.ProtocolError;
+    IRequestOnConn getRequestOnConnForNode ( AddrPort node_address, ProtocolError e );
 }
 
 /*******************************************************************************

--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -273,6 +273,14 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
 
     /***************************************************************************
 
+        Used by `RequestOnConnSet`.
+
+    ***************************************************************************/
+
+    public bool active;
+
+    /***************************************************************************
+
         Serialised request context data, set when starting a new request and
         passed to all request handlers when the request fiber is started.
 

--- a/src/swarm/neo/client/RequestOnConnSet.d
+++ b/src/swarm/neo/client/RequestOnConnSet.d
@@ -135,6 +135,7 @@ public struct RequestOnConnSet
     {
         this.list ~= request_on_conn;
         this.num_active++;
+        request_on_conn.active = true;
 
         return request_on_conn;
     }
@@ -167,6 +168,7 @@ public struct RequestOnConnSet
             "request-on-connection already exists for the specified node");
 
         this.num_active++;
+        request_on_conn.active = true;
 
         return request_on_conn;
     }
@@ -250,20 +252,29 @@ public struct RequestOnConnSet
 
     /***************************************************************************
 
-        Decrements the `num_active` counter and returns whether it is now 0.
+        Registers `roc` as inactive, decrements the `num_active` counter and
+        returns whether the counter is now 0.
+
+        Params:
+            roc = the `RequestOnConn` instance that has finished
 
         Returns:
             true if `num_active` is 0
 
     ***************************************************************************/
 
-    public bool finished ( )
+    public bool finished ( RequestOnConn roc )
     in
     {
         assert(this.num_active);
     }
     body
     {
+        // TODO: Consider `this.all_nodes.remove(roc)` instead of using the
+        // `active` flag. Not doing this now for a patch release to avoid
+        // potentially introducing a bug if there is an unobvious reason why it
+        // isn't done.
+        roc.active = false;
         return --this.num_active == 0;
     }
 


### PR DESCRIPTION
In several situations, including a node shutdown and client/node protocol mismatch, the client can receive a message for a request-on-conn whose fiber has already terminated. Throw a protocol error to initiate a shutdown to prevent `RequestOnConn.setReceivedPayload` from attempting to resume the terminated fiber.

Fixes #309.