### PR TITLE
Add missing import for ProtocolError

### DIFF
--- a/src/swarm/neo/client/RequestSet.d
+++ b/src/swarm/neo/client/RequestSet.d
@@ -40,6 +40,7 @@ public final class RequestSet: IRequestSet
     import swarm.neo.client.RequestOnConnSet;
     import swarm.neo.client.RequestHandlers;
     import swarm.neo.connection.YieldedRequestOnConns;
+    import swarm.neo.protocol.ProtocolError;
     import swarm.neo.util.TreeMap;
     import ocean.transition;
     import swarm.neo.AddrPort;


### PR DESCRIPTION
Add the import to the ProtocolError, since it's used in the RequestSet class.

Fixes #313