### PR TITLE
Enable TCP_NODELAY for the client before adding nodes

### DIFF
--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -239,6 +239,7 @@ template ClientCore ( )
             settings.conn_notifier, settings.auto_connect);
         this.request_resources = settings.request_resources;
 
+        this.enableSocketNoDelay();
         this.addNodes(config.nodes_file());
     }
 


### PR DESCRIPTION
In case the NeoConfig enabled constructor is used, the TCP_NODELAY
can't be set downstream, because it needs to be set before the nodes
are added, and the swarm user is not able to do that if the nodes are
added in the constructor. This simply turns the TCP_NODELAY on when
constructing the neo client.

Adding it here to fix the issue in swarm v4.6.x/v5.0.x - this behaviour is on by default in the next,
not yet released minor.