### PR TITLE
Make RequestOnConn.AbortException public

### DIFF
--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -345,7 +345,7 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
 
     ***************************************************************************/
 
-    private static class AbortException : Exception
+    public static class AbortException : Exception
     {
         /***********************************************************************
 


### PR DESCRIPTION
Request handlers might need to catch exceptions of this type, and cannot do so if it's private.