### PR TITLE
Stop using to-be-deprecated `getMsg`

### DIFF
--- a/src/swarm/README_client_neo.rst
+++ b/src/swarm/README_client_neo.rst
@@ -168,13 +168,13 @@ delegate looks something like this imaginary example:
     with ( info.Active ) switch ( info.active ) 
     {
       case success: // example success notification
-        Stdout.formatln("Request on channel {} succeeded and returned the "
+        Stdout.formatln("Request on channel {} succeeded and returned the " ~
             "value {}", args.channel, info.value);
         break;
 
       case error: // example I/O error notification
-        Stderr.formatln("Request on channel {} failed due to error {} "
-            "on {}:{}", args.channel, getMsg(info.e),
+        Stderr.formatln("Request on channel {} failed due to error {} " ~
+            "on {}:{}", args.channel, info.e.message(),
             cast(char[])info.node_addr.address_bytes, info.node_addr.port);
         break;
 

--- a/src/swarm/client/connection/RequestConnection.d
+++ b/src/swarm/client/connection/RequestConnection.d
@@ -817,14 +817,14 @@ public abstract class IRequestConnection :
             // connection.
             debug ( SwarmClient ) Stderr.formatln("[{}:{}.{}]: Caught fiber kill exception: {}",
                 this.conn_pool.address, this.conn_pool.port,
-                this.id, getMsg(e));
+                this.id, e.message());
             throw e;
         }
         catch ( Exception e )
         {
             debug ( SwarmClient ) Stderr.formatln("[{}:{}.{}]: Caught exception in fiber: {}",
                 this.conn_pool.address, this.conn_pool.port,
-                this.id, getMsg(e));
+                this.id, e.message());
             this.exception = e;
         }
     }
@@ -931,7 +931,7 @@ public abstract class IRequestConnection :
         {
             debug ( SwarmClient ) Stderr.formatln("[{}:{}.{}]: An exception was caught while handling the request: {}",
                 this.conn_pool.address, this.conn_pool.port,
-                this.id, getMsg(this.exception));
+                this.id, this.exception.message());
             this.disconnect();
         }
     }

--- a/src/swarm/client/request/notifier/IRequestNotification.d
+++ b/src/swarm/client/request/notifier/IRequestNotification.d
@@ -286,7 +286,7 @@ public scope class IRequestNotification
                     this.notification_description,
                     this.nodeitem.Address, this.nodeitem.Port,
                     this.command_description, this.status_description,
-                    getMsg(this.exception), this.exception.file, this.exception.line);
+                    this.exception.message(), this.exception.file, this.exception.line);
             }
             else
             {
@@ -294,7 +294,7 @@ public scope class IRequestNotification
                     this.notification_description,
                     this.nodeitem.Address, this.nodeitem.Port,
                     this.command_description, this.status_description,
-                    getMsg(this.exception));
+                    this.exception.message());
             }
         }
 

--- a/src/swarm/client/request/params/IRequestParams.d
+++ b/src/swarm/client/request/params/IRequestParams.d
@@ -198,7 +198,7 @@ public abstract class IRequestParams
                 {
                     log.error("exception caught while calling notifier "
                               ~ "delegate: '{}' @ {}:{}",
-                              getMsg(e), e.file, e.line);
+                              e.message(), e.file, e.line);
                 }
             });
         }

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -472,7 +472,7 @@ public final class Connection: ConnectionBase
             // This may happen if the timer failed due to OS resource
             // exhaustion.
             log.error("connect: retry failed - {} @{}:{}",
-                getMsg(e), e.file, e.line);
+                e.message(), e.file, e.line);
             this.status_ = this.status_.Disconnected;
         }
 
@@ -549,7 +549,7 @@ public final class Connection: ConnectionBase
             debug ( SwarmConn )
                 Stdout.formatln("{}:{}: Connection.tryConnect() failed with "
                     "exception '{}' @{}:{}", node_address.address_bytes,
-                    node_address.port, getMsg(e), e.file, e.line);
+                    node_address.port, e.message(), e.file, e.line);
             return false;
         }
 

--- a/src/swarm/neo/client/NotifierTypes.d
+++ b/src/swarm/neo/client/NotifierTypes.d
@@ -183,7 +183,7 @@ public struct NodeExceptionInfo
             sformat(sink,
                 "Exception '{}' @ {}:{} occurred in the client while handling the "
                 "request on node {}:{}",
-                getMsg(this.e), this.e.file, this.e.line,
+                this.e.message(), this.e.file, this.e.line,
                 this.node_addr.address_bytes, this.node_addr.port);
         }
         else
@@ -232,7 +232,7 @@ public struct RequestNodeExceptionInfo
             sformat(sink,
                 "Exception '{}' @ {}:{} occurred in the client while handling "
                 "request #{} on node {}:{}",
-                getMsg(this.e), this.e.file, this.e.line, this.request_id,
+                this.e.message(), this.e.file, this.e.line, this.request_id,
                 this.node_addr.address_bytes, this.node_addr.port);
         }
         else

--- a/src/swarm/neo/client/RetryTimer.d
+++ b/src/swarm/neo/client/RetryTimer.d
@@ -223,7 +223,7 @@ private final class TimerEvent: ISelectClient
         }
         catch (Exception e)
         {
-            auto msg = getMsg(e);
+            auto msg = e.message();
             stdio.fprintf(stdio.stderr, ("Error unregistering " ~
                     typeof(this).stringof ~
                     " from epoll: %.*s @%s:%u\n\0").ptr,

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -330,13 +330,14 @@ abstract class ConnectionBase: ISelectClient
                     debug ( SwarmConn )
                         Stdout.formatln("SendLoop.fiberMethod(): ResumeException! @{}:{}", e.file, e.line);
 
-                    log.error("SendLoop: {} @{}:{}", getMsg(e), e.file, e.line);
+                    log.error("SendLoop: {} @{}:{}", e.message(), e.file, e.line);
                     throw e;
                 }
                 catch (Exception e)
                 {
                     debug ( SwarmConn )
-                        Stdout.formatln("SendLoop.fiberMethod() caught \"{}\" @{}:{}", getMsg(e), e.file, e.line);
+                        Stdout.formatln("SendLoop.fiberMethod() caught \"{}\"@{}:{}",
+                            e.message(), e.file, e.line);
 
                     this.outer.shutdownImpl(e);
                     this.send_loop_exited_ex = e;
@@ -350,7 +351,7 @@ abstract class ConnectionBase: ISelectClient
             {
                 debug ( SwarmConn )
                     Stdout.formatln("SendLoop.fiberMethod() caught \"{}\" @{}:{} while connecting",
-                        getMsg(e), e.file, e.line);
+                        e.message(), e.file, e.line);
 
                 this.outer.shutdownImpl(e);
                 this.send_loop_exited_ex = e;
@@ -614,7 +615,7 @@ abstract class ConnectionBase: ISelectClient
             }
             catch (ResumeException e)
             {
-                log.error("ReceiveLoop: {} @{}:{}", getMsg(e), e.file, e.line);
+                log.error("ReceiveLoop: {} @{}:{}", e.message(), e.file, e.line);
             }
             catch (Exception e)
             {

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -151,7 +151,8 @@ class Connection: ConnectionBase
     {
         debug (SwarmConn)
         {
-            Stdout.formatln("node connection shutdown \"{}\" @{}:{}", getMsg(e), e.file, e.line);
+            Stdout.formatln("node connection shutdown \"{}\" @{}:{}",
+                e.message(), e.file, e.line);
             scope (success) Stdout.formatln("node connection shutdown success");
             scope (failure) Stdout.formatln("node connection shutdown failure");
         }

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -642,7 +642,7 @@ class ConnectionHandler : IConnectionHandler
         {
             log.error("{}:{}: Exception thrown from request handler: {} @ {}:{}",
                 this.connection.connected_client, rq.name,
-                getMsg(e), e.file, e.line);
+                e.message(), e.file, e.line);
             throw e;
         }
     }

--- a/src/swarm/neo/protocol/connect/ConnectProtocol.d
+++ b/src/swarm/neo/protocol/connect/ConnectProtocol.d
@@ -442,7 +442,7 @@ class ConnectProtocol: ISelectClient
         catch (Exception e)
         {
             Log.lookup(this.classinfo.name).error("unregisterEpoll: {} @{}:{}",
-                getMsg(e), e.file, e.line);
+                e.message(), e.file, e.line);
         }
     }
 

--- a/src/swarm/node/connection/ConnectionHandler.d
+++ b/src/swarm/node/connection/ConnectionHandler.d
@@ -801,12 +801,12 @@ abstract public class ISwarmConnectionHandler : IFiberConnectionHandlerBase,
             if ( this.cmd )
             {
                 Stderr.formatln("[{}]: Error handling request {}: '{}'",
-                super.connection_id, this.cmd, getMsg(e));
+                super.connection_id, this.cmd, e.message());
             }
             else
             {
                 Stderr.formatln("[{}]: Error reading request command: '{}'",
-                super.connection_id, getMsg(e));
+                super.connection_id, e.message());
             }
         }
 

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -956,7 +956,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
         catch (Exception e)
         {
             send_response("Error updating credentials: ");
-            send_response(getMsg(e));
+            send_response(e.message());
             send_response("\n");
         }
     }


### PR DESCRIPTION
In all supported compiler versions it is possible to directly
call `Exception.message()`.