### PR TITLE
Log IOError node exceptions with info level.

### DIFF
--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -55,6 +55,7 @@ class ConnectionHandler : IConnectionHandler
     import swarm.neo.request.Command;
 
     import ocean.io.select.EpollSelectDispatcher;
+    import ocean.io.select.protocol.generic.ErrnoIOException;
     import ocean.time.StopWatch;
 
     import ClassicSwarm =
@@ -637,6 +638,13 @@ class ConnectionHandler : IConnectionHandler
         try
         {
             handle_request();
+        }
+        catch ( IOError e )
+        {
+            log.info("{}:{}: IOError thrown from request handler: {} @ {}:{}",
+                this.connection.connected_client, rq.name,
+                e.message(), e.file, e.line);
+            throw e;
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
If the client ever dies during the handling of the request (which
is amplified by the long-living requests), `IOError` will be thrown
in the node and it will be logged as an error. This is not an error
from the node's PoV and it's logged now with an info level.