### PR TITLE
 List registered clients to a Unix domain socket 

### DIFF
--- a/relnotes/listcredentials.feature.md
+++ b/relnotes/listcredentials.feature.md
@@ -1,0 +1,7 @@
+### List registered clients to a Unix domain socket
+
+  * `swarm.neo.node.NeoNode`
+
+  New command has been added to the unix socket domain
+  interface: `list-credentials`, which will list the
+  currently regsitered client names to the connected socket.

--- a/src/swarm/neo/authentication/NodeCredentials.d
+++ b/src/swarm/neo/authentication/NodeCredentials.d
@@ -102,6 +102,21 @@ public class Credentials
 
     /***************************************************************************
 
+        Passes the list of registered clients to a delegate, one by one.
+
+        Params:
+            sink = delegate to pass registered clients to.
+
+    ***************************************************************************/
+
+    public void listRegisteredClients ( void delegate ( cstring ) sink )
+    {
+        foreach (client, _; this.credentials_)
+            sink(client);
+    }
+
+    /***************************************************************************
+
         Specialised exception class containing the file and line where a parsing
         error occurred.
 


### PR DESCRIPTION
New command has been added to the unix socket domain interface:
`list-credentials`, which will list the currently regsitered client
names to the connected socket.

Fixes #339