### PR TITLE
Remove internal deprecations.

### DIFF
--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -239,7 +239,6 @@ template ClientCore ( )
             settings.conn_notifier, settings.auto_connect);
         this.request_resources = settings.request_resources;
 
-        this.enableSocketNoDelay();
         this.addNodes(config.nodes_file());
     }
 

--- a/src/swarm/util/RecordBatcher.d
+++ b/src/swarm/util/RecordBatcher.d
@@ -647,7 +647,7 @@ unittest
 {
     auto lzo = new Lzo;
     auto writer = new RecordBatcher(lzo, 200);
-    auto reader = new RecordBatch(lzo, 200);
+    auto reader = new RecordBatch(lzo);
 
     mstring key, value_S, value_M, value_L;
     key.length = 16;
@@ -702,7 +702,7 @@ unittest
 {
     auto lzo = new Lzo;
     auto writer = new RecordBatcher(lzo, RecordBatcher.DefaultMaxBatchSize * 10);
-    auto reader = new RecordBatch(lzo, RecordBatcher.DefaultMaxBatchSize);
+    auto reader = new RecordBatch(lzo);
 
     ubyte[] compressed;
     uint added;


### PR DESCRIPTION
This PR removes references to deprecated methods in swarm from unittests, so swarm doesn't hit it's own deprecations.