### PR TITLE
Sanitize the input array length

### DIFF
--- a/relnotes/readarray.bug.md
+++ b/relnotes/readarray.bug.md
@@ -1,0 +1,6 @@
+### Validate the length of the array before reading it
+
+* `swarm.protocol.FiberSelectReader`
+
+`FiberSelectReader` will not reject to read arrays larger
+than (by default) 10MB and it will throw `InputTooLargeException`.


### PR DESCRIPTION
FiberSelectReader now will throw an exception if the array
length is larger than FiberSelectReader.max_array_size (defaults
to 10MB). This will prevent allocation of the huge amounts of memory
on the invalid data.