### PR TITLE
Set max_array_size from the second constructor in FiberSelectReader

### DIFF
--- a/src/swarm/protocol/FiberSelectReader.d
+++ b/src/swarm/protocol/FiberSelectReader.d
@@ -80,7 +80,7 @@ public class FiberSelectReader : Ocean.FiberSelectReader
     public IAddrPort addr_port;
 
     /// Maximum array size to read
-    protected size_t max_array_size;
+    protected size_t max_array_size = 10 * 1024 * 1024;
 
     /***************************************************************************
 

--- a/src/swarm/protocol/FiberSelectReader.d
+++ b/src/swarm/protocol/FiberSelectReader.d
@@ -118,13 +118,16 @@ public class FiberSelectReader : Ocean.FiberSelectReader
         Params:
             socket      = socket to read from
             buffer_size = input buffer size
+            max_array_size = maximum array length to allow
 
     ***************************************************************************/
 
     public this ( IFiberSelectProtocol socket,
-           size_t buffer_size = this.default_buffer_size )
+        size_t buffer_size = this.default_buffer_size,
+        size_t max_array_size = 10 * 1024 * 1024 )
     {
         super(socket, buffer_size);
+        this.max_array_size = max_array_size;
     }
 
     /***************************************************************************


### PR DESCRIPTION
This field was set only from the first constructor, failing to
set it from the second, making it zero.