### PR TITLE
Adapt Neo/Node unittests to actually instantiate node class

### DIFF
--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -1068,9 +1068,27 @@ version (UnitTest)
         }
         override protected void handleCommand () {}
     }
+
+    private class TestNode : NodeBase!(TestConnectionHandler)
+    {
+        public this ( )
+        {
+            super(NodeItem("127.0.0.1".dup, 2323), new ConnectionSetupParams, 1);
+        }
+
+        protected override cstring id ( )
+        {
+            return "test";
+        }
+
+        protected override void getResourceAcquirer (
+            void delegate ( Object resource_acquirer ) handle_request_dg )
+        {
+        }
+   }
 }
 
 unittest
 {
-    alias NodeBase!(TestConnectionHandler) Instance;
+    auto node = new TestNode;
 }

--- a/src/swarm/node/model/Node.d
+++ b/src/swarm/node/model/Node.d
@@ -698,9 +698,22 @@ version (UnitTest)
         }
         override protected void handleCommand () {}
     }
+
+    private class TestNode : NodeBase!(TestConnectionHandler)
+    {
+        public this ( )
+        {
+            super(NodeItem("127.0.0.1".dup, 2323), new ConnectionSetupParams, 1);
+        }
+
+        protected override cstring id ( )
+        {
+            return "test";
+        }
+   }
 }
 
 unittest
 {
-    alias NodeBase!(TestConnectionHandler) Instance;
+    auto node = new TestNode;
 }


### PR DESCRIPTION
This tests that all expected base class and interface methods are implemented, not merely that the code is syntactically correct.