### PR TITLE
Add methods to set AddrPort from NodeItem and convert back

### DIFF
--- a/relnotes/addrport.feature.md
+++ b/relnotes/addrport.feature.md
@@ -1,0 +1,12 @@
+### Methods to convert between `AddrPort` and `NodeItem`
+
+`swarm.neo.AddrPort`
+
+Swarm uses two address/port representations internally (for historical reasons).
+In the future, we will remove the old `NodeItem`, but for now it's useful to
+have convenient methods for converting back and forth.
+
+`AddrPort` now has the following new methods:
+  * `typeof(this) set ( NodeItem node_item )`
+  * `NodeItem asNodeItem ( ref mstring buf )`
+

--- a/src/swarm/neo/AddrPort.d
+++ b/src/swarm/neo/AddrPort.d
@@ -25,10 +25,14 @@ public struct AddrPort
     import core.sys.posix.arpa.inet: ntohl, ntohs, htonl, htons, inet_ntop;
     import core.stdc.string: strlen;
 
-    import ocean.util.container.map.model.StandardHash;
+    import swarm.Const : NodeItem;
 
+    import ocean.util.container.map.model.StandardHash;
     import ocean.core.Test;
     import swarm.util.Verify;
+
+    /// Minimum length required for an address format buffer.
+    public const AddrBufLength = INET6_ADDRSTRLEN;
 
     /***************************************************************************
 
@@ -268,6 +272,43 @@ public struct AddrPort
         this.naddress = src.sin_addr.s_addr;
         this.nport    = src.sin_port;
         return this;
+    }
+
+    /***************************************************************************
+
+        Sets the address and port of this instance to those in node_item.
+
+        Params:
+            node_item = the input address and port
+
+        Returns:
+            this instance
+
+    ***************************************************************************/
+
+    public typeof(this) set ( NodeItem node_item )
+    {
+        this.port = node_item.Port;
+        this.setAddress(node_item.Address);
+        return this;
+    }
+
+    /***************************************************************************
+
+        Gets the address and port of this instance in the format of a NodeItem.
+
+        Params:
+            buf = buffer used to format the address. Must be at least
+                AddrBufLength bytes long
+
+        Returns:
+            NodeItem instance
+
+    ***************************************************************************/
+
+    public NodeItem asNodeItem ( ref mstring buf )
+    {
+        return NodeItem(this.getAddress(buf), this.port);
     }
 
     /***************************************************************************


### PR DESCRIPTION
As part of replacing internal usages of NodeItem with AddrPort, it's useful
to have a convenient way of converting from one to the other.

Part of #348.