### PR TITLE
Add suspend unregister callback

### DIFF
--- a/relnotes/unregister_suspendables.feature.md
+++ b/relnotes/unregister_suspendables.feature.md
@@ -1,0 +1,6 @@
+### Add suspend unregister callback
+
+* `swarm.client.RequestSetup`
+
+Adds a delegate that may be used in any proto to give applications an option to
+remove instances of type `ISuspendable` when a suspendable request finishes.

--- a/src/swarm/LibFeatures.d
+++ b/src/swarm/LibFeatures.d
@@ -14,6 +14,8 @@
 
 module swarm.LibFeatures;
 
+
+const has_features_5_2 = true;
 const has_features_5_1 = true;
 const has_features_5_0 = true;
 const has_features_4_7 = true;


### PR DESCRIPTION
This may be used in any proto to give applications an option to
remove instances of type ISuspendable when a suspendable request
finishes.