### PR TITLE
Verify that neo client config instance is non-null before using it

### DIFF
--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -153,6 +153,8 @@ template ClientCore ( )
 
     private this ( Config config, Settings settings )
     {
+        verify(config !is null, "Neo config instance is null!");
+
         Credentials cred;
         cred.setFromFile(config.credentials_file());
 


### PR DESCRIPTION
This patch adds a small but useful sanity check to the constructor for neo client support.  This should ensure that failure to instantiate the neo client config class properly results in an informative exception and error message rather than a segfault.