### PR TITLE
Don't wait for the connection to be reestablished for single node requests

### DIFF
--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -782,6 +782,11 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
         if (!this.connection)
             return false;
 
+        auto client_connection = cast(Connection)this.connection;
+        assert(client_connection);
+        if (client_connection.status != Connection.Status.Connected)
+            return false;
+
         scope (exit)
         {
             // the request may decide to use another connection, so we need to


### PR DESCRIPTION
In case when the connection was never established to the node, all
single-node requests will fail, because the connection will not be found
in the connection set. However, in case when the connection breaks
during the lifetime of the client, the client will keep scheduling
requests for the connection until the connection is reeastablished.

This change checks the connection status before starting the single-node
request. In case the connection is not established, the client report the
same error as if the connection was never established.