### PR TITLE
Fix crash when a request is finished during a throttledTaskPool resume

### DIFF
--- a/src/swarm/neo/client/RequestOnConnSet.d
+++ b/src/swarm/neo/client/RequestOnConnSet.d
@@ -197,8 +197,12 @@ public struct RequestOnConnSet
 
             case AllNodes:
                 foreach ( roc; this.map )
+                {
                     if ( auto ret = dg(roc) )
                         return ret;
+                    if (this.num_active == 0)
+                        break;
+                }
                 return 0;
 
             version (D_Version2) {} else default: assert(false);


### PR DESCRIPTION
It looks like the map is cleared immediately after a request is done. If this happens during `ISuspendableThrottler.throttledResume()` which iterates through the map, the app will crash.