### PR TITLE
Pass received data as `const(void)[]` from `EventDispatcher.receive`

### DIFF
--- a/integrationtest/neo/client/request/internal/Get.d
+++ b/integrationtest/neo/client/request/internal/Get.d
@@ -150,9 +150,8 @@ public struct VersionedGet ( ubyte Version )
                             context.shared_working.result =
                                 SharedWorking.Result.Received;
 
-                            scope recv_cb = ( in void[] const_payload )
+                            scope recv_cb = ( const(void)[] payload )
                             {
-                                Const!(void)[] payload = const_payload;
                                 auto value =
                                     conn.message_parser.getArray!(void)(payload);
 

--- a/relnotes/RequestOnConn.migration.md
+++ b/relnotes/RequestOnConn.migration.md
@@ -1,0 +1,4 @@
+### `EventDispatcher.receive` passes received data as `const(void)[]`
+
+The delegate parameter of the `EventDispatcher.receive()` method now takes
+an array of const values, instead of a const array.

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -867,7 +867,8 @@ abstract class RequestOnConnBase
 
         ***********************************************************************/
 
-        public void receive ( scope void delegate ( in void[] payload ) received )
+        public void receive (
+            scope void delegate ( const(void)[] payload ) received )
         {
             auto event = this.nextEvent(NextEventFlags.Receive);
             received(event.received.payload);


### PR DESCRIPTION
The delegate parameter of the `EventDispatcher.receive()` method now takes an array of const values, instead of a const array.