### PR TITLE
Add static checks for members of `Request` type in `ConnectionHandler`

### DIFF
--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -111,7 +111,22 @@ class ConnectionHandler : IConnectionHandler
 
         public void addHandler ( Request : IRequest ) ( )
         {
-            assert(Request.name.length > 0);
+            static void memberExists ( istring name, T ) ( )
+            {
+                static assert (
+                    hasMember!(Request, name)
+                        && is(typeof(mixin("Request." ~ name)) : T),
+                    Request.stringof ~ " should have a static member named '"
+                    ~ name ~ "' of type '" ~ T.stringof ~ "'.");
+            }
+
+            memberExists!("name", istring);
+            memberExists!("command", Command);
+            memberExists!("timing", bool);
+            memberExists!("scheduled_for_removal", bool);
+
+            static assert(Request.name.length > 0,
+                "'Request.name' should have a non-zero length.");
 
             RequestInfo ri;
             ri.name = Request.name;


### PR DESCRIPTION
This ensures that these members are defined with the correct typein the
implementation of the `IRequest` interface, as they are needed in the
`ConnectionHandler.addHandler` method.