### PR TITLE
Remove use of deprecated FieldName template

### DIFF
--- a/src/swarm/node/connection/ConnectionHandler.d
+++ b/src/swarm/node/connection/ConnectionHandler.d
@@ -299,12 +299,15 @@ public abstract class ConnectionHandlerTemplate ( Commands : ICommandCodes )
                     // FIXME_IN_D2: can't use `const` inside static foreach
                     // while it is converted in `static immutable`
                     mixin("auto buffer = acquired."
-                        ~ FieldName!(i, Resources) ~ ";");
+                        ~ __traits(identifier, Resources.tupleof[i]) ~ ";");
                     if ( buffer.length > this.bufferSizeWarnLimit() )
                     {
-                        log.warn("Request resource '{}' grew to {} bytes while " ~
-                            "handling {}", FieldName!(i, Resources), buffer.length,
-                            request.description(this.cmd_description));
+                        log.warn("Request resource '{}' grew to {} bytes while"
+                            ~ " handling {}",
+                            __traits(identifier, Resources.tupleof[i]),
+                            buffer.length,
+                            request.description(this.cmd_description)
+                        );
                     }
                 }
             }


### PR DESCRIPTION
FieldName is long deprecated in ocean and was
removed in the latest major version.