### PR TITLE
Add public MessageParser alias to RequestOnConnBase.EventDispatcher

### DIFF
--- a/relnotes/RequestOnConn.migration.md
+++ b/relnotes/RequestOnConn.migration.md
@@ -2,3 +2,11 @@
 
 The delegate parameter of the `EventDispatcher.receive()` method now takes
 an array of const values, instead of a const array.
+
+### `EventDispatcher` now exposes `MessageParser` via an explicit alias
+
+Various downstream code relies on being able to access `MessageParser` via
+the `EventDispatcher` class, but this only works because the module import
+is treated as implicitly public by the D compiler, and as of D 2.087 this
+no longer works.  The new public alias should prevent this without needing
+any changes from downstream code which expect the symbol to be visible.

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -229,6 +229,11 @@ abstract class RequestOnConnBase
 
         alias RequestOnConnBase.FiberResumeCode FiberResumeCode;
 
+        /// Helper alias to allow access to the specific `MessageParser`
+        /// type used by this class
+        public alias MessageParser =
+            swarm.neo.protocol.MessageParser.MessageParser;
+
         /**********************************************************************/
 
         invariant ( )


### PR DESCRIPTION
The `MessageParser` symbol is expected to be publicly available via the `EventDispatcher` class by some downstream code (e.g. `RequestHandler` in dmqproto), but this is only possible due to implicitly public imports that will stop working for D frontend versions 2.087.0 and later.

Making it available via a public alias both fixes the short-term problem and also allows us an easy route to deprecate this usage in future if we wish to do so.