### PR TITLE
Fix synchronization for RecordStream

### DIFF
--- a/relnotes/record-stream-sync.bug.md
+++ b/relnotes/record-stream-sync.bug.md
@@ -1,0 +1,16 @@
+### Fix synchronization for RecordStream
+
+`src/swarm/util/RecordStream.d`
+
+The stream must be only suspended if the method suspend has been currently
+called.
+This is required since ISuspendableThrottler (from ocean v5) ensures that
+the suspend state of an ISuspendable instance when added to a throttler is
+consistent with the throttler state.
+Without this patch-fix if a RecordStream is added as suspendable to
+a throttler then it will try to process the stream because `suspended()`
+was checking for the running state of the fiber and that would make an
+application  crash in the best case or having unexpected behaviour.
+To avoid this situation the `suspended()` implementation now only
+checks if the stream is suspended meaning that suspend() has been
+currently called.

--- a/src/swarm/util/RecordStream.d
+++ b/src/swarm/util/RecordStream.d
@@ -469,6 +469,16 @@ public class StdinRecordStream : ISuspendable
 
     /***************************************************************************
 
+        Flag indicating whether the stream is currently suspended.
+        The flag is only set when a call to suspend() has been done and unset
+        when resume() is called.
+
+    ***************************************************************************/
+
+    private bool is_suspended;
+
+    /***************************************************************************
+
         Constructor.
 
         Params:
@@ -494,6 +504,7 @@ public class StdinRecordStream : ISuspendable
 
     public bool process ( )
     {
+        this.is_suspended = false;
         this.fiber.start();
         return this.end_of_stream;
     }
@@ -507,6 +518,7 @@ public class StdinRecordStream : ISuspendable
 
     override public void suspend ( )
     {
+        this.is_suspended = true;
         this.fiber.suspend(token);
     }
 
@@ -518,19 +530,31 @@ public class StdinRecordStream : ISuspendable
 
     override public void resume ( )
     {
+        this.is_suspended = false;
         this.fiber.resume(token);
     }
 
     /***************************************************************************
 
+        Checks if the stream is suspended meaning that the method suspend()
+        has been currently called.
+
         Returns:
-            true if the process is suspended
+            true if the process is suspended (a suspend() has been called)
 
     ***************************************************************************/
 
     override public bool suspended ( )
     {
-        return !this.fiber.running;
+        return this.is_suspended;
+    }
+
+    /// Test the stream is not suspended right after instantiation.
+    unittest
+    {
+        auto null_dg = null;
+        auto stream = new StdinRecordStream(null_dg);
+        test!("==")(stream.suspended, false);
     }
 
     /***************************************************************************

--- a/src/swarm/util/RecordStream.d
+++ b/src/swarm/util/RecordStream.d
@@ -47,12 +47,6 @@ public struct Record
     import ocean.io.stream.Lines;
     import Base64 = ocean.util.encode.Base64;
 
-    version ( UnitTest )
-    {
-        import ocean.core.Test;
-    }
-
-
     /***************************************************************************
 
         Record key. 16-character hex-string or empty.


### PR DESCRIPTION
The stream must be only suspended if the method suspend has been currently
called.
This is required since ISuspendableThrottler (from ocean v5) ensures that
the suspend state of an ISuspendable instance when added to a throttler is
consistent with the throttler state.
Without this patch-fix if a RecordStream is added as suspendable to
a throttler then it will try to process the stream because `suspended()`
was checking for the running state of the fiber and that would make an
application  crash in the best case or having unexpected behaviour.
To avoid this situation the `suspended()` implementation now only
checks if the stream is suspended meaning that suspend() has been
currently called.