### PR TITLE
Change version(UnitTest) -> version(unittest)

### DIFF
--- a/integrationtest/client_auth/main.d
+++ b/integrationtest/client_auth/main.d
@@ -24,7 +24,7 @@ import ocean.io.select.EpollSelectDispatcher;
 import Config = ocean.util.config.ConfigFiller;
 import ocean.util.config.ConfigParser;
 
-version (UnitTest) {}
+version ( unittest ) {}
 else
 void main ( )
 {

--- a/integrationtest/client_stats/main.d
+++ b/integrationtest/client_stats/main.d
@@ -23,7 +23,7 @@ import ocean.util.test.DirectorySandbox;
 
 import swarm.util.log.ClientStats;
 
-version ( UnitTest ) {}
+version ( unittest ) {}
 else void main ( )
 {
     // Create temporary sandbox directory to write files to.

--- a/integrationtest/neo/main.d
+++ b/integrationtest/neo/main.d
@@ -537,7 +537,7 @@ class Test : Task
 
 *******************************************************************************/
 
-version (UnitTest) {}
+version ( unittest ) {}
 else
 void main ( )
 {

--- a/integrationtest/record_stream/main.d
+++ b/integrationtest/record_stream/main.d
@@ -29,7 +29,7 @@ import core.sys.posix.unistd;
 import core.sys.posix.sys.wait;
 
 
-version (UnitTest) {} else
+version ( unittest ) {} else
 public int main ()
 {
     int[2] pipes;

--- a/integrationtest/turtleenv/main.d
+++ b/integrationtest/turtleenv/main.d
@@ -97,7 +97,7 @@ private class TestNode : Node!(TurtleNode, "turtleNode")
     }
 }
 
-version (UnitTest){}
+version ( unittest ){}
 else
 void main()
 {

--- a/src/swarm/Const.d
+++ b/src/swarm/Const.d
@@ -26,7 +26,7 @@ import ocean.io.digest.Fnv1;
 import ocean.transition;
 import core.stdc.ctype : isalnum;
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 }

--- a/src/swarm/client/RequestSetup.d
+++ b/src/swarm/client/RequestSetup.d
@@ -808,7 +808,7 @@ public template StreamInfo ( )
 }
 
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Tuple;
 }

--- a/src/swarm/client/helper/NodesConfigReader.d
+++ b/src/swarm/client/helper/NodesConfigReader.d
@@ -50,7 +50,7 @@ import ocean.io.device.File;
 
 import Integer = ocean.text.convert.Integer_tango;
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
 }

--- a/src/swarm/client/request/params/IRequestParams.d
+++ b/src/swarm/client/request/params/IRequestParams.d
@@ -562,7 +562,7 @@ public abstract class IRequestParams
     }
 }
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/common/connection/ISharedResources.d
+++ b/src/swarm/common/connection/ISharedResources.d
@@ -185,7 +185,7 @@ template SharedResources_T ( T )
     }
 }
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/common/request/model/IRequestResources.d
+++ b/src/swarm/common/request/model/IRequestResources.d
@@ -475,14 +475,15 @@ public template RequestResources_T ( Shared )
         mixin(Initialisers!(Shared.Resources));
     }
 }
-version (UnitTest)
+
+version ( unittest )
 {
     import ocean.core.Test;
 
     // to avoid clashing of mixed in names from different module tests
     struct LocalNamespace
     {
-        // ISharedResources module has a version (UnitTest) mixin
+        // ISharedResources module has a version (unittest) mixin
         // that provides SharedResources symbol
         public import swarm.common.connection.ISharedResources
             : UnitTestClashFix;

--- a/src/swarm/neo/AddrPort.d
+++ b/src/swarm/neo/AddrPort.d
@@ -15,7 +15,7 @@ module swarm.neo.AddrPort;
 import core.sys.posix.netinet.in_; // in_addr, in_addr_t, in_port_t, socklen_t, sockaddr_in, AF_INET
 
 import ocean.transition;
-version ( UnitTest ) import ocean.core.Test;
+version ( unittest ) import ocean.core.Test;
 
 extern (C) int inet_aton(Const!(char)* src, in_addr* dst);
 

--- a/src/swarm/neo/authentication/CredentialsFile.d
+++ b/src/swarm/neo/authentication/CredentialsFile.d
@@ -243,7 +243,7 @@ public class CredentialsParseException: Exception
 
 /******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.core.ByteSwap;

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -886,7 +886,7 @@ private struct ConnectionRegistry ( C )
 
 *******************************************************************************/
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.core.Verify;

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -517,7 +517,7 @@ template ClientCore ( )
         }
     }
 
-    version ( UnitTest )
+    version ( unittest )
     {
         import ocean.io.Stdout;
     }
@@ -936,7 +936,7 @@ template ClientCore ( )
 
 *******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.io.Stdout;
 

--- a/src/swarm/neo/client/mixins/Controllers.d
+++ b/src/swarm/neo/client/mixins/Controllers.d
@@ -325,7 +325,7 @@ template Controllers ( )
 }
 
 /// Unit test instantiating the templates to detect semantic errors
-version (UnitTest) private class ControllersTemplateTest
+version ( unittest ) private class ControllersTemplateTest
 {
     import swarm.neo.protocol.Message: RequestId;
 

--- a/src/swarm/neo/client/mixins/DeserializeMethod.d
+++ b/src/swarm/neo/client/mixins/DeserializeMethod.d
@@ -76,7 +76,7 @@ template DeserializeMethod ( alias src )
 
 public VersionDecorator client_deserializer_version_decorator;
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.util.serialize.contiguous.Contiguous;

--- a/src/swarm/neo/client/mixins/SerializeMethod.d
+++ b/src/swarm/neo/client/mixins/SerializeMethod.d
@@ -50,7 +50,7 @@ template SerializeMethod ( alias dst )
     }
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.util.serialize.contiguous.Contiguous;

--- a/src/swarm/neo/client/request_options/RequestOptions.d
+++ b/src/swarm/neo/client/request_options/RequestOptions.d
@@ -295,7 +295,7 @@ private istring assertArgsHandled ( size_t n_args, ArgsAndHandlers ... ) ( )
     return result.length? "static assert(false,\"" ~ result ~ "\");" : null;
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/neo/client/requests/NotificationFormatter.d
+++ b/src/swarm/neo/client/requests/NotificationFormatter.d
@@ -165,7 +165,7 @@ public void format ( T ) ( T notification )
     }
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -627,7 +627,7 @@ class ConnectionHandler : IConnectionHandler
     }
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import swarm.node.request.RequestStats;
     import swarm.neo.request.Command;

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -273,7 +273,7 @@ struct IoVecTracker
 
     /**************************************************************************/
 
-    version ( UnitTest )
+    version ( unittest )
     {
         import ocean.core.Test: test;
         import ocean.transition;

--- a/src/swarm/neo/util/Batch.d
+++ b/src/swarm/neo/util/Batch.d
@@ -447,7 +447,7 @@ private bool recordFieldsSupported ( Record ... ) ( )
     return true;
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/neo/util/StructPacker.d
+++ b/src/swarm/neo/util/StructPacker.d
@@ -186,7 +186,7 @@ private void packDynamicArray ( A ) ( ref A[] array, ref void[] buf )
         static assert(!hasIndirections!(A));
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.core.DeepCompare : deepEquals;

--- a/src/swarm/neo/util/Util.d
+++ b/src/swarm/neo/util/Util.d
@@ -121,7 +121,7 @@ char[] TupleToSlices ( Types ... ) ( istring name )
     return code;
 }
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.core.Tuple;

--- a/src/swarm/node/model/IChannelsNodeInfo.d
+++ b/src/swarm/node/model/IChannelsNodeInfo.d
@@ -97,7 +97,7 @@ public interface IChannelsNodeInfo : INodeInfo
 
 *******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     public class TestChannelsNode : TestNode, IChannelsNodeInfo
     {

--- a/src/swarm/node/model/INodeInfo.d
+++ b/src/swarm/node/model/INodeInfo.d
@@ -199,7 +199,7 @@ public interface INodeInfo
 
 *******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     public class TestNode : INodeInfo
     {

--- a/src/swarm/node/model/NeoChannelsNode.d
+++ b/src/swarm/node/model/NeoChannelsNode.d
@@ -229,7 +229,7 @@ public class ChannelsNodeBase (
 }
 
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.net.server.connection.IConnectionHandler;
 

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -1057,7 +1057,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 }
 
 
-version (UnitTest)
+version ( unittest )
 {
     private class TestConnectionHandler : ISwarmConnectionHandler
     {

--- a/src/swarm/node/model/RecordActionCounters.d
+++ b/src/swarm/node/model/RecordActionCounters.d
@@ -150,7 +150,7 @@ public class RecordActionCounters
 
 /******************************************************************************/
 
-version (UnitTest)
+version ( unittest )
 {
     import ocean.core.Test;
 

--- a/src/swarm/node/request/RequestStats.d
+++ b/src/swarm/node/request/RequestStats.d
@@ -34,7 +34,7 @@ module swarm.node.request.RequestStats;
 import ocean.transition;
 import ocean.core.Verify;
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 }

--- a/src/swarm/node/storage/listeners/Listeners.d
+++ b/src/swarm/node/storage/listeners/Listeners.d
@@ -360,7 +360,7 @@ public class IListeners ( Data ... )
     }
 }
 
-version (UnitTest) import ocean.core.Test;
+version ( unittest ) import ocean.core.Test;
 
 unittest
 {

--- a/src/swarm/util/Hash.d
+++ b/src/swarm/util/Hash.d
@@ -65,7 +65,7 @@ import core.stdc.string: memmove;
 
 import Integer = ocean.text.convert.Integer_tango;
 
-version (UnitTest) import ocean.core.Test;
+version ( unittest ) import ocean.core.Test;
 
 class InvalidHashException: Exception
 {
@@ -523,7 +523,7 @@ public template isKeyType ( T )
 
 *******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.math.random.Random;
 

--- a/src/swarm/util/RecordBatcher.d
+++ b/src/swarm/util/RecordBatcher.d
@@ -610,7 +610,7 @@ public class RecordBatch
     }
 }
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.text.convert.Formatter;

--- a/src/swarm/util/RecordStream.d
+++ b/src/swarm/util/RecordStream.d
@@ -23,7 +23,7 @@ import ocean.io.model.ISuspendable;
 import ocean.io.serialize.SimpleStreamSerializer;
 import ocean.io.Console : Cin, Cout, Console;
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
 }

--- a/src/swarm/util/node/log/Stats.d
+++ b/src/swarm/util/node/log/Stats.d
@@ -77,7 +77,7 @@ private class NodeStatsTemplate ( Logger = StatsLog )
 
     ***************************************************************************/
 
-    version ( UnitTest ) { }
+    version ( unittest ) { }
     else
     {
         static assert(is(Logger == StatsLog));
@@ -386,7 +386,7 @@ private class ChannelsNodeStatsTemplate ( Logger = StatsLog )
 
 *******************************************************************************/
 
-version ( UnitTest )
+version ( unittest )
 {
     import ocean.core.Test;
     import ocean.meta.codegen.Identifier : identifier;


### PR DESCRIPTION
Another stage of D2 migration. Allows unit tests to be run with `-unittest` instead of `-unittest -version=UnitTest`.