### PR TITLE
Replace deprecated D1 operator overloads

### DIFF
--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -662,7 +662,12 @@ private struct ConnectionRegistry ( C )
     }
 
     // ditto
-    public alias get opIn_r;
+
+    public template opBinaryRight (string op : "in")
+    {
+        alias opBinaryRight = get;
+    }
+
 
     /***************************************************************************
 

--- a/src/swarm/neo/util/TreeMap.d
+++ b/src/swarm/neo/util/TreeMap.d
@@ -200,7 +200,7 @@ struct TreeMap ( Node = eb64_node )
 
         ***********************************************************************/
 
-        public UserElement opIn_r ( ulong key )
+        public UserElement opBinaryRight (string op : "in") ( ulong key )
         {
             return nodeToUserElement(cast(Node*)eb64_lookup(&this.root, key));
         }
@@ -396,7 +396,7 @@ struct TreeMap ( Node = eb64_node )
 
         ***********************************************************************/
 
-        public Node* opIn_r ( ulong key )
+        public Node* opBinaryRight (string op : "in") ( ulong key )
         {
             return cast(Node*)eb64_lookup(&this.root, key);
         }


### PR DESCRIPTION
To reduce compilation warnings when compiling with dmd 2.088 and later.
These are the simple cases, where the operators are members of structs, so the fact that the operators are non-virtual is not a problem.
