### PR TITLE
Remove use of genOpCmp, genOpEquals mixins

### DIFF
--- a/src/swarm/Const.d
+++ b/src/swarm/Const.d
@@ -23,7 +23,8 @@ import ocean.core.Enum;
 
 import ocean.io.digest.Fnv1;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+
 import core.stdc.ctype : isalnum;
 
 version ( unittest )
@@ -190,7 +191,7 @@ public struct NodeItem
 
     ***************************************************************************/
 
-    public mixin (genOpCmp(`
+    int opCmp ( const typeof(this) rhs ) const
     {
         if ( this.Address > rhs.Address ) return 1;
         if ( this.Address < rhs.Address ) return -1;
@@ -198,7 +199,7 @@ public struct NodeItem
         if ( this.Port < rhs.Port ) return -1;
 
         return 0;
-    }`));
+    }
 }
 
 

--- a/src/swarm/client/connection/NodeConnectionPool.d
+++ b/src/swarm/client/connection/NodeConnectionPool.d
@@ -19,9 +19,9 @@ module swarm.client.connection.NodeConnectionPool;
 
 *******************************************************************************/
 
-import ocean.transition;
-
 import ocean.core.Verify;
+
+import ocean.meta.types.Qualifiers;
 
 import swarm.Const;
 
@@ -309,13 +309,12 @@ public abstract class NodeConnectionPool
 
     ***************************************************************************/
 
-    public mixin(genOpCmp(`
+    public override int opCmp ( Object rhs )
     {
         auto other = cast(typeof(this)) rhs;
         verify(other !is null);
         return this.node_item.opCmp(other.node_item);
     }
-    `));
 
 
     /**************************************************************************

--- a/src/swarm/node/request/RequestStats.d
+++ b/src/swarm/node/request/RequestStats.d
@@ -31,8 +31,8 @@
 
 module swarm.node.request.RequestStats;
 
-import ocean.transition;
 import ocean.core.Verify;
+import ocean.meta.types.Qualifiers;
 
 version ( unittest )
 {
@@ -950,11 +950,10 @@ public class RequestStats
 
             *******************************************************************/
 
-            mixin (genOpEquals("
+            bool opEquals ( const typeof(this) rhs ) const
             {
                 return this.request == rhs.request && this.client == rhs.client;
             }
-            "));
 
             /*******************************************************************
 
@@ -970,11 +969,10 @@ public class RequestStats
 
             *******************************************************************/
 
-            mixin (genOpCmp("
+            int opCmp ( const typeof(this) rhs ) const
             {
                 return this.request != rhs.request || this.client != rhs.client;
             }
-            "));
         }
 
         /// Per-client/request information map.


### PR DESCRIPTION
These mixins were only required during D2 transition, and can now be removed.