### PR TITLE
Add annotations for fns which `return &this`

### DIFF
--- a/src/swarm/client/RequestSetup.d
+++ b/src/swarm/client/RequestSetup.d
@@ -164,7 +164,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* notifier ( scope IRequestNotification.Callback notifier )
+    public This* notifier ( scope IRequestNotification.Callback notifier ) return
     {
         this.notification_dg = notifier;
         return &this;
@@ -183,7 +183,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* timeout ( uint timeout_ms )
+    public This* timeout ( uint timeout_ms ) return
     {
         this.timeout_ms = timeout_ms;
         return &this;
@@ -202,7 +202,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* context ( RequestContext context )
+    public This* context ( RequestContext context ) return
     {
         this.user_context = context;
         return &this;
@@ -221,7 +221,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* context ( void* context )
+    public This* context ( void* context ) return
     {
         this.user_context = RequestContext(context);
         return &this;
@@ -240,7 +240,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* context ( Object context )
+    public This* context ( Object context ) return
     {
         this.user_context = RequestContext(context);
         return &this;
@@ -259,7 +259,7 @@ public template RequestBase ( )
 
     ***************************************************************************/
 
-    public This* context ( hash_t context )
+    public This* context ( hash_t context ) return
     {
         this.user_context = RequestContext(context);
         return &this;
@@ -508,7 +508,7 @@ public template Node ( )
 
     ***************************************************************************/
 
-    public This* allNodes ( )
+    public This* allNodes ( ) return
     {
         this.node_item = NodeItem();
         return &this;
@@ -527,7 +527,7 @@ public template Node ( )
 
     ***************************************************************************/
 
-    public This* node ( NodeItem node )
+    public This* node ( NodeItem node ) return
     {
         verify(node.set(), "Invalid NodeItem passed to node()!");
         this.node_item = node;
@@ -548,7 +548,7 @@ public template Node ( )
 
     ***************************************************************************/
 
-    public This* node ( mstring address, ushort port )
+    public This* node ( mstring address, ushort port ) return
     {
         this.node_item = NodeItem(address, port);
         return &this;
@@ -611,7 +611,7 @@ public template Channel ( )
 
     ***************************************************************************/
 
-    public This* channel ( cstring channel )
+    public This* channel ( cstring channel ) return
     {
         this.channel_name = channel;
         return &this;
@@ -693,7 +693,7 @@ public template Suspendable ( )
 
     public This* suspendable (
         RequestParams.RegisterSuspendableDg suspend_register,
-        RequestParams.RegisterSuspendableDg suspend_unregister = null )
+        RequestParams.RegisterSuspendableDg suspend_unregister = null ) return
     {
         this.suspend_register = suspend_register;
         this.suspend_unregister = suspend_unregister;
@@ -781,7 +781,7 @@ public template StreamInfo ( )
     ***************************************************************************/
 
     public This* stream_info (
-        RequestParams.RegisterStreamInfoDg stream_info_register )
+        RequestParams.RegisterStreamInfoDg stream_info_register ) return
     {
         this.stream_info_register = stream_info_register;
         return &this;

--- a/src/swarm/neo/AddrPort.d
+++ b/src/swarm/neo/AddrPort.d
@@ -267,7 +267,7 @@ public struct AddrPort
 
     ***************************************************************************/
 
-    public typeof(&this) set ( sockaddr_in src )
+    public typeof(&this) set ( sockaddr_in src ) return
     {
         this.naddress = src.sin_addr.s_addr;
         this.nport    = src.sin_port;
@@ -286,7 +286,7 @@ public struct AddrPort
 
     ***************************************************************************/
 
-    public typeof(&this) set ( NodeItem node_item )
+    public typeof(&this) set ( NodeItem node_item ) return
     {
         this.port = node_item.Port;
         this.setAddress(node_item.Address);

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -53,7 +53,8 @@ struct IoVecMessage // MessageGenerator
 
     ***************************************************************************/
 
-    IoVecTracker* setup ( MessageType type, in void[][] dynamic_fields, in void[][] static_fields ... )
+    IoVecTracker* setup ( MessageType type, in void[][] dynamic_fields,
+        in void[][] static_fields ... ) return
     {
         verify(type <= type.max);
 


### PR DESCRIPTION
From dmd2.092 onwards, functions which use the `return &this` method chaining idiom, must be marked with the `return` annotation. This makes it impossible for @safe code to have references to destructed stack objects (see DIP25).

Fixes deprecation messages which occur with dmd2.092 beta.