### PR TITLE
Add a missing `return` annotation to neo.AddrPort

### DIFF
--- a/src/swarm/neo/AddrPort.d
+++ b/src/swarm/neo/AddrPort.d
@@ -231,7 +231,7 @@ public struct AddrPort
 
     ***************************************************************************/
 
-    public ubyte[] address_bytes ( )
+    public ubyte[] address_bytes ( ) return
     {
         return (cast(ubyte*)&this.naddress)[0 .. this.naddress.sizeof];
     }


### PR DESCRIPTION
This function returns a reference to the struct it is part of, so needs to be marked with `return` for DMD 2.092.