### PR TITLE
Add -dip25 to Build.mak, to check dmd 2.092

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,4 +1,4 @@
-override DFLAGS += -w
+override DFLAGS += -w -dip25
 override LDFLAGS += -lebtree -llzo2 -lrt -lgcrypt -lgpg-error -lglib-2.0
 
 DC ?= dmd


### PR DESCRIPTION
DMD 2.092 has not actually been released yet, but the main breaking
change it has it that -dip25 is enabled. So -dip25 should be set for
all supported compilers.