### PR TITLE
Fix variable shadowing + other compiler warnings

### DIFF
--- a/src/swarm/client/plugins/NodeDeactivator.d
+++ b/src/swarm/client/plugins/NodeDeactivator.d
@@ -304,7 +304,8 @@ public class NodeDeactivator
 
             // For each node, check whether it exceeds the threshold and the
             // warning level.
-            foreach ( node, counter; mixin(instance).error_tracker.node_counters )
+            foreach ( n, counter;
+                mixin(instance).error_tracker.node_counters )
             {
                 debug ( NodeDeactivator ) Stderr.formatln("err={}, thrsh={}, warn={}",
                     counter.per_sec, mixin(instance).threshold, warning_level);
@@ -313,7 +314,7 @@ public class NodeDeactivator
                      && counter.per_sec > warning_level )
                 {
                     debug ( NodeDeactivator ) Stderr.formatln("    Disabled");
-                    this.deactivate(node, mean_error_rate);
+                    this.deactivate(n, mean_error_rate);
                 }
             }
         }

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -510,10 +510,10 @@ template ClientCore ( )
                     rcv_stats.socket.total);
 
             // Connection send queue stats iteration.
-            foreach ( node, stats; stats.connection_send_queue )
+            foreach ( node, queue_stats; stats.connection_send_queue )
                 Stdout.formatln("{}:{}: total {} microseconds queued time",
                     node.address_bytes, node.port,
-                    stats.time_histogram.total_time_micros);
+                    queue_stats.time_histogram.total_time_micros);
         }
     }
 

--- a/src/swarm/neo/client/request_options/RequestContext.d
+++ b/src/swarm/neo/client/request_options/RequestContext.d
@@ -204,7 +204,7 @@ public struct RequestContext
 
     ***************************************************************************/
 
-    private ContextUnion* context ( ) const
+    private ContextUnion* context ( ) const return
     {
         return cast(ContextUnion*)this.context_.ptr;
     }

--- a/src/swarm/node/model/IChannelsNodeInfo.d
+++ b/src/swarm/node/model/IChannelsNodeInfo.d
@@ -57,6 +57,8 @@ public interface IChannelsNodeInfo : INodeInfo
 
         Looks up channels by id.
 
+        Alias to opIn_r for backwards compatibility.
+
         Params:
             id = id of channel to look up
 
@@ -67,6 +69,9 @@ public interface IChannelsNodeInfo : INodeInfo
     ***************************************************************************/
 
     public IStorageEngineInfo* opIn_r ( cstring id );
+
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 
 
     /***************************************************************************

--- a/src/swarm/node/model/NeoChannelsNode.d
+++ b/src/swarm/node/model/NeoChannelsNode.d
@@ -200,6 +200,8 @@ public class ChannelsNodeBase (
 
         Looks up channels by id.
 
+        Aliased to opIn_r for backwards compatibility.
+
         Params:
             id = id of channel to look up
 
@@ -213,6 +215,10 @@ public class ChannelsNodeBase (
     {
         return cast(IStorageEngineInfo*)(id in this.channels);
     }
+
+    /** ditto */
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 
 
     /***************************************************************************

--- a/src/swarm/node/storage/model/IStorageChannels.d
+++ b/src/swarm/node/storage/model/IStorageChannels.d
@@ -124,6 +124,8 @@ abstract public class IStorageChannelsTemplate ( Storage : IStorageEngine )
 
         Looks up channel_id in registered channels.
 
+        Alias to opIn_r for backwards compatibility.
+
         Params:
             channel_id = channel identifier string to lookup
 
@@ -136,6 +138,8 @@ abstract public class IStorageChannelsTemplate ( Storage : IStorageEngine )
     {
         return channel_id in this.channels;
     }
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 
 
     /***************************************************************************


### PR DESCRIPTION
There are a couple of instances of foreach variable shadowing, a missing `return` annotation, and
some D1-style `in` operators which need D2 replacements.

After these changes, when my ocean fixes are merged, swarm unittests compile cleanly on dmd 2.092 beta, with the exception of the two 'escaping variable' issues which I created an issue about.