### PR TITLE
Remove usage and mentions of `ocean.stdc`

### DIFF
--- a/src/swarm/neo/client/RetryTimer.d
+++ b/src/swarm/neo/client/RetryTimer.d
@@ -14,6 +14,7 @@ module swarm.neo.client.RetryTimer;
 
 import core.stdc.errno;
 import stdio = core.stdc.stdio;
+import core.stdc.string;
 import core.sys.posix.sys.time;
 import core.sys.posix.time;
 
@@ -21,7 +22,6 @@ import ocean.core.Verify;
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.select.client.model.ISelectClient;
 import ocean.meta.types.Qualifiers;
-import ocean.stdc.string;
 import ocean.sys.TimerFD;
 
 import swarm.neo.util.FiberTokenHashGenerator;

--- a/src/swarm/neo/client/RetryTimer.d
+++ b/src/swarm/neo/client/RetryTimer.d
@@ -12,24 +12,21 @@
 
 module swarm.neo.client.RetryTimer;
 
-import ocean.sys.TimerFD;
-
-import swarm.neo.util.MessageFiber;
-
-import ocean.io.select.EpollSelectDispatcher;
-import ocean.io.select.client.model.ISelectClient;
-
-import core.sys.posix.time;
-import core.sys.posix.sys.time;
 import core.stdc.errno;
-
-import swarm.neo.util.FiberTokenHashGenerator;
-
 import stdio = core.stdc.stdio;
-import ocean.stdc.string;
-import ocean.meta.types.Qualifiers;
+import core.sys.posix.sys.time;
+import core.sys.posix.time;
 
 import ocean.core.Verify;
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.io.select.client.model.ISelectClient;
+import ocean.meta.types.Qualifiers;
+import ocean.stdc.string;
+import ocean.sys.TimerFD;
+
+import swarm.neo.util.FiberTokenHashGenerator;
+import swarm.neo.util.MessageFiber;
+
 
 /*******************************************************************************
 
@@ -61,7 +58,7 @@ void retry ( lazy bool success, MessageFiber fiber, EpollSelectDispatcher epoll 
     timespec t_end;
     clock_gettime(clockid_t.CLOCK_MONOTONIC, &t_end);
 
-    scope e = new TimerFD.TimerException;	
+    scope e = new TimerFD.TimerException;
     scope timer = new TimerFD(e);
     scope event = new TimerEvent(epoll, fiber, timer, t_start, t_end);
 

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -261,7 +261,7 @@ class ConnectionHandler : IConnectionHandler
             Constructor.
 
             Note that `unix_socket_path.length` needs to be less than
-            `UNIX_PATH_MAX`, a constant defined in `ocean.stdc.posix.sys.un`.
+            `core.sys.posix.sys.un : UNIX_PATH_MAX`.
 
             Params:
                 epoll = epoll dispatcher used by the node

--- a/src/swarm/neo/protocol/connect/ConnectProtocol.d
+++ b/src/swarm/neo/protocol/connect/ConnectProtocol.d
@@ -34,10 +34,9 @@ class ConnectProtocol: ISelectClient
 
     import ocean.meta.traits.Indirections : hasIndirections;
 
-    import ocean.stdc.posix.sys.socket;
-    import ocean.stdc.string: strerror_r, strlen;
-
     import core.stdc.errno: ENOENT;
+    import core.stdc.string: strerror_r, strlen;
+    import core.sys.posix.sys.socket;
 
     import ocean.util.log.Logger;
 


### PR DESCRIPTION
All the functions and symbols used here have long been in druntime and can be used instead of the thin wrapper in ocean.