### PR TITLE
Remove v2.071.2.s* from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.071.2.s* F=production
-        - <<: *test-matrix
-          env: DMD=2.071.2.s* F=devel
-        - <<: *test-matrix
           env: DMD=2.078.* F=production
         - <<: *test-matrix
           env: DMD=2.078.* F=devel


### PR DESCRIPTION
This compiler is long gone and there is no interest in supporting it in the future.
This is the lowest hanging fruit in the matrix and will allow upstream to move
forward immediately.