### PR TITLE
Fix deprecations for invalid printf format

### DIFF
--- a/src/swarm/neo/authentication/HmacAuthCode.d
+++ b/src/swarm/neo/authentication/HmacAuthCode.d
@@ -132,8 +132,9 @@ struct HmacAuthCode
         }
         catch (GCryptError e)
         {
-            cstdio.fprintf(cstdio.stderr, "libgcrypt test for SHA512 failed: %.*s @%s:%u\n".ptr,
-                    e.msg.length, e.msg.ptr, e.file.ptr, e.line);
+            cstdio.fprintf(cstdio.stderr,
+                    "libgcrypt test for SHA512 failed: %.*s @%s:%zu\n".ptr,
+                    cast(int) e.msg.length, e.msg.ptr, e.file.ptr, e.line);
             exit(EXIT_FAILURE);
         }
     }

--- a/src/swarm/neo/client/RetryTimer.d
+++ b/src/swarm/neo/client/RetryTimer.d
@@ -222,8 +222,8 @@ private final class TimerEvent: ISelectClient
             auto msg = e.message();
             stdio.fprintf(stdio.stderr, ("Error unregistering " ~
                     typeof(this).stringof ~
-                    " from epoll: %.*s @%s:%u\n\0").ptr,
-                    msg.length, msg.ptr, e.file.ptr, e.line);
+                    " from epoll: %.*s @%s:%zu\n\0").ptr,
+                    cast(int) msg.length, msg.ptr, e.file.ptr, e.line);
         }
     }
 


### PR DESCRIPTION
Pretty trivial. The only other deprecations left are due to DIP25 but they are non-trivial to fix.