### PR TITLE
Fixup for PR425: Deprecate swarm.util.Verify

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -2,3 +2,7 @@ override DFLAGS += -w
 override LDFLAGS += -lebtree -llzo2 -lrt -lgcrypt -lgpg-error -lglib-2.0
 
 DC ?= dmd
+
+# Remove deprecated modules from testing:
+TEST_FILTER_OUT += \
+	$C/src/swarm/util/Verify.d

--- a/src/swarm/neo/AddrPort.d
+++ b/src/swarm/neo/AddrPort.d
@@ -29,7 +29,7 @@ public struct AddrPort
 
     import ocean.util.container.map.model.StandardHash;
     import ocean.core.Test;
-    import swarm.util.Verify;
+    import ocean.core.Verify;
 
     /// Minimum length required for an address format buffer.
     public enum AddrBufLength = INET6_ADDRSTRLEN;


### PR DESCRIPTION
The PR was missing an exclusion from the Build.mak,
and I missed the only deprecation message it triggered
thanks to the sea of deprecations from Ocean.