### PR TITLE
Drop compatibility for anything less than v2.092

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
-        - DIST=xenial
-        - COV=1
+        - DIST=bionic
+        - COV=0
 
 # Basic config is inherited from the global scope
 jobs:
@@ -33,17 +33,17 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.078.* F=production
+          env: DMD=2.092.* F=production
         - <<: *test-matrix
-          env: DMD=2.078.* F=devel
+          env: DMD=2.092.* F=devel
         - <<: *test-matrix
-          env: DMD=2.085.* F=production
+          env: DMD=2.093.* F=production COV=1
         - <<: *test-matrix
-          env: DMD=2.085.* F=devel
+          env: DMD=2.093.* F=devel COV=1
 
         # Additional stages
 
         - stage: Closure allocation check
-          env: DMD=2.071.2.s* F=devel
+          env: DMD=2.093.* F=devel
           install: beaver dlang install
           script: ci/closures.sh

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v5
+FROM sociomantictsunami/develdlang:v8


### PR DESCRIPTION
```
Since we want to drop support for dmd-transitional,
we need to settle on the minimum supported version of DMD.
Due to the various deprecations and some codeggen bugs in -O -inline,
only v2.092.0 and higher is able to compile our code correctly.

Additionally we now only test on bionic instead of xenial,
and reduced coverage to only the latest version of the compiler.
```

This comes as a replacement of #405 . In it, @daniel-zullo-sociomantic mentioned [a codegen bug](https://issues.dlang.org/show_bug.cgi?id=20441) which was fixed in v2.089.1.