### PR TITLE
Update ocean and turtle to HEAD, fix deprecations, use Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       # or build flavour we still want to see how things perform with the others
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-20.04 ]
         dc: [ dmd-2.092.1, dmd-2.093.1 ]
         flavor: [ prod, devel ]
         # Not a matrix row, but referenced as a constant in this file

--- a/integrationtest/client_stats/main.d
+++ b/integrationtest/client_stats/main.d
@@ -52,7 +52,7 @@ class App : Application
         this.registerExtension(this.rof_ext);
     }
 
-    override protected int run ( istring[] args )
+    override protected int run ( string[] args )
     {
         return 0;
     }

--- a/integrationtest/neo/client/request/internal/GetAll.d
+++ b/integrationtest/neo/client/request/internal/GetAll.d
@@ -139,7 +139,7 @@ public struct GetAll
 
 *******************************************************************************/
 
-private scope class GetAllImpl
+private class GetAllImpl
 {
     import swarm.neo.connection.RequestOnConnBase;
     import swarm.neo.client.mixins.AllNodesRequestCore;

--- a/integrationtest/neo/node/Node.d
+++ b/integrationtest/neo/node/Node.d
@@ -56,7 +56,7 @@ public class Node : NodeBase!(ConnHandler)
     {
         assert(neo_port > 2);
     }
-    body
+    do
     {
         // In this simple example node implementation, we don't need any shared
         // resources except the reference to the storage.

--- a/integrationtest/neo/node/request/DoublePut.d
+++ b/integrationtest/neo/node/request/DoublePut.d
@@ -36,7 +36,7 @@ public class DoublePutImpl_v0 : IRequest
     static immutable Command command = Command(RequestCode.DoublePut, 0);
 
     /// Request name for stats tracking. Required by ConnectionHandler.
-    static immutable istring name = "DoublePut";
+    static immutable string name = "DoublePut";
 
     /// Flag indicating whether timing stats should be gathered for requests of
     /// this type.

--- a/integrationtest/neo/node/request/Get.d
+++ b/integrationtest/neo/node/request/Get.d
@@ -36,7 +36,7 @@ public class GetImpl_v0 : IRequest
     static immutable Command command = Command(RequestCode.Get, 0);
 
     /// Request name for stats tracking. Required by ConnectionHandler.
-    static immutable istring name = "Get";
+    static immutable string name = "Get";
 
     /// Flag indicating whether timing stats should be gathered for requests of
     /// this type.

--- a/integrationtest/neo/node/request/GetAll.d
+++ b/integrationtest/neo/node/request/GetAll.d
@@ -38,7 +38,7 @@ public class GetAllImpl_v0 : IRequest
     static immutable Command command = Command(RequestCode.GetAll, 0);
 
     /// Request name for stats tracking. Required by ConnectionHandler.
-    static immutable istring name = "GetAll";
+    static immutable string name = "GetAll";
 
     /// Flag indicating whether timing stats should be gathered for requests of
     /// this type.

--- a/integrationtest/neo/node/request/Put.d
+++ b/integrationtest/neo/node/request/Put.d
@@ -36,7 +36,7 @@ public class PutImpl_v0 : IRequest
     static immutable Command command = Command(RequestCode.Put, 0);
 
     /// Request name for stats tracking. Required by ConnectionHandler.
-    static immutable istring name = "Put";
+    static immutable string name = "Put";
 
     /// Flag indicating whether timing stats should be gathered for requests of
     /// this type.

--- a/integrationtest/neo/node/request/RoundRobinPut.d
+++ b/integrationtest/neo/node/request/RoundRobinPut.d
@@ -36,7 +36,7 @@ public class RoundRobinPutImpl_v0 : IRequest
     static immutable Command command = Command(RequestCode.RoundRobinPut, 0);
 
     /// Request name for stats tracking. Required by ConnectionHandler.
-    static immutable istring name = "RoundRobinPut";
+    static immutable string name = "RoundRobinPut";
 
     /// Flag indicating whether timing stats should be gathered for requests of
     /// this type.

--- a/integrationtest/record_stream/main.d
+++ b/integrationtest/record_stream/main.d
@@ -83,7 +83,7 @@ public void runListener ()
     assert(eos, "End Of Stream not received!");
 }
 
-private static immutable istring[] Verbatim = [
+private static immutable string[] Verbatim = [
     "\n\n\n",
     "bbbbbbbbbbbbbbbb:AAAAAAAAAAAAAAAA\n",
 ];

--- a/src/swarm/client/ClientExceptions.d
+++ b/src/swarm/client/ClientExceptions.d
@@ -35,7 +35,7 @@ public class ClientException : Exception
 {
     mixin DefaultExceptionCtor!();
 
-    public typeof(this) opCall ( istring file, long line )
+    public typeof(this) opCall ( string file, long line )
     {
         super.file = file;
         super.line = line;

--- a/src/swarm/client/connection/RequestOverflow.d
+++ b/src/swarm/client/connection/RequestOverflow.d
@@ -491,7 +491,7 @@ public class DiskOverflow : IRequestOverflow
     {
         assert (queue !is null, "Creation of FlexibleFileQueue failed");
     }
-    body
+    do
     {
         auto queue = node.toHash in this.disk_queues;
         if ( queue is null )

--- a/src/swarm/client/helper/NodesConfigReader.d
+++ b/src/swarm/client/helper/NodesConfigReader.d
@@ -185,7 +185,7 @@ static:
 
     unittest
     {
-        istring content = "
+        string content = "
         127.0.0.1:4000
         127.0.0.2:5000 # comment
         # 127.0.0.3:6000";

--- a/src/swarm/client/model/IClient.d
+++ b/src/swarm/client/model/IClient.d
@@ -84,7 +84,7 @@ public abstract class IClient
 
         ***********************************************************************/
 
-        istring nodes_file;
+        string nodes_file;
 
         /***********************************************************************
 
@@ -302,7 +302,7 @@ public abstract class IClient
 
     ***************************************************************************/
 
-    static public size_t nodesInConfigFile ( istring file )
+    static public size_t nodesInConfigFile ( string file )
     {
         auto nodes = NodesConfigReader(file);
         return nodes.length;

--- a/src/swarm/client/plugins/NodeDeactivator.d
+++ b/src/swarm/client/plugins/NodeDeactivator.d
@@ -174,7 +174,7 @@ public class NodeDeactivator
 
     ***************************************************************************/
 
-    template Extension ( istring instance )
+    template Extension ( string instance )
     {
         /***********************************************************************
 

--- a/src/swarm/client/plugins/RequestQueueDiskOverflow.d
+++ b/src/swarm/client/plugins/RequestQueueDiskOverflow.d
@@ -92,7 +92,7 @@ public class RequestQueueDiskOverflow
 
     ***************************************************************************/
 
-    template Extension ( istring instance )
+    template Extension ( string instance )
     {
         import swarm.client.connection.RequestOverflow;
 

--- a/src/swarm/client/plugins/RequestScheduler.d
+++ b/src/swarm/client/plugins/RequestScheduler.d
@@ -253,7 +253,7 @@ public class RequestScheduler
 
     ***************************************************************************/
 
-    template Extension ( istring instance )
+    template Extension ( string instance )
     {
         /***********************************************************************
 

--- a/src/swarm/client/plugins/ScopeRequests.d
+++ b/src/swarm/client/plugins/ScopeRequests.d
@@ -32,7 +32,7 @@ public class ScopeRequestsPlugin
 
     ***************************************************************************/
 
-    template Extension ( istring instance )
+    template Extension ( string instance )
     {
         /***********************************************************************
 
@@ -57,7 +57,7 @@ public class ScopeRequestsPlugin
 
         ***********************************************************************/
 
-        public scope class ScopeRequests
+        public class ScopeRequests
         {
             /*******************************************************************
 

--- a/src/swarm/client/registry/DisablableNodeSet.d
+++ b/src/swarm/client/registry/DisablableNodeSet.d
@@ -88,7 +88,7 @@ public class DisablableNodeSet : NodeSet
         assert(!(node in this.map), "node in set after disable()");
         assert(node in this.disabled_nodes, "node not disabled after disable()");
     }
-    body
+    do
     {
         verify(!(node in this.disabled_nodes), "node already disabled");
 
@@ -115,7 +115,7 @@ public class DisablableNodeSet : NodeSet
         assert(node in this.map, "node not in set after enable()");
         assert(!(node in this.disabled_nodes), "node disabled after enabled()");
     }
-    body
+    do
     {
         auto conn_pool = node in this.disabled_nodes;
         enforce(this.no_node_exception(node.Address, node.Port), conn_pool !is null);

--- a/src/swarm/client/registry/FluidNodeRegistry.d
+++ b/src/swarm/client/registry/FluidNodeRegistry.d
@@ -99,7 +99,7 @@ public class FluidNodeRegistry : NodeRegistry, IFluidNodeRegistry
     {
         assert(!this.inRegistry(address, port), "node in registry after remove()");
     }
-    body
+    do
     {
         this.nodes.remove(NodeItem(address, port));
     }
@@ -125,7 +125,7 @@ public class FluidNodeRegistry : NodeRegistry, IFluidNodeRegistry
     {
         assert(!this.inRegistry(address, port), "node in registry after disable()");
     }
-    body
+    do
     {
         debug ( SwarmClient ) Stderr.formatln("Disabling {}:{}", address, port);
 
@@ -153,7 +153,7 @@ public class FluidNodeRegistry : NodeRegistry, IFluidNodeRegistry
     {
         assert(this.inRegistry(address, port), "node not in registry after enable()");
     }
-    body
+    do
     {
         debug ( SwarmClient ) Stderr.formatln("Enabling {}:{}", address, port);
 
@@ -198,7 +198,7 @@ public class FluidNodeRegistry : NodeRegistry, IFluidNodeRegistry
 
     ***************************************************************************/
 
-    private scope class DisabledIterator : IDisabledIterator
+    private class DisabledIterator : IDisabledIterator
     {
         /***********************************************************************
 

--- a/src/swarm/client/registry/NodeRegistry.d
+++ b/src/swarm/client/registry/NodeRegistry.d
@@ -201,7 +201,7 @@ public abstract class NodeRegistry : INodeRegistry
     {
         assert(this.inRegistry(address, port), "node not in registry after add()");
     }
-    body
+    do
     {
         this.nodes.add(NodeItem(address, port),
             this.newConnectionPool(address, port));

--- a/src/swarm/client/registry/model/IFluidNodeRegistryInfo.d
+++ b/src/swarm/client/registry/model/IFluidNodeRegistryInfo.d
@@ -94,4 +94,3 @@ public interface IFluidNodeRegistryInfo : INodeRegistryInfo
 
     void disabled_nodes ( scope void delegate ( IDisabledIterator ) dg );
 }
-

--- a/src/swarm/client/request/GetChannelSizeRequest.d
+++ b/src/swarm/client/request/GetChannelSizeRequest.d
@@ -39,7 +39,7 @@ import swarm.Const : ICommandCodes;
 
 *******************************************************************************/
 
-public scope class GetChannelSizeRequestTemplate ( Base : IRequest, Resources,
+public class GetChannelSizeRequestTemplate ( Base : IRequest, Resources,
     ICommandCodes.Value Cmd ) : Base
 {
     /***************************************************************************

--- a/src/swarm/client/request/GetChannelsRequest.d
+++ b/src/swarm/client/request/GetChannelsRequest.d
@@ -39,7 +39,7 @@ import swarm.Const : ICommandCodes;
 
 *******************************************************************************/
 
-public scope class GetChannelsRequestTemplate ( Base : IRequest, Resources,
+public class GetChannelsRequestTemplate ( Base : IRequest, Resources,
     ICommandCodes.Value Cmd ) : Base
 {
     /***************************************************************************

--- a/src/swarm/client/request/GetNumConnectionsRequest.d
+++ b/src/swarm/client/request/GetNumConnectionsRequest.d
@@ -39,7 +39,7 @@ import swarm.Const : ICommandCodes;
 
 *******************************************************************************/
 
-public scope class GetNumConnectionsRequestTemplate ( Base : IRequest, Resources,
+public class GetNumConnectionsRequestTemplate ( Base : IRequest, Resources,
     ICommandCodes.Value Cmd ) : Base
 {
     /***************************************************************************

--- a/src/swarm/client/request/GetSizeRequest.d
+++ b/src/swarm/client/request/GetSizeRequest.d
@@ -39,7 +39,7 @@ import swarm.Const : ICommandCodes;
 
 *******************************************************************************/
 
-public scope class GetSizeRequestTemplate ( Base : IRequest, Resources,
+public class GetSizeRequestTemplate ( Base : IRequest, Resources,
     ICommandCodes.Value Cmd ) : Base
 {
     /***************************************************************************

--- a/src/swarm/client/request/RemoveChannelRequest.d
+++ b/src/swarm/client/request/RemoveChannelRequest.d
@@ -36,7 +36,7 @@ import swarm.Const : ICommandCodes;
 
 *******************************************************************************/
 
-public scope class RemoveChannelRequestTemplate ( Base : IRequest, Resources,
+public class RemoveChannelRequestTemplate ( Base : IRequest, Resources,
     ICommandCodes.Value Cmd ) : Base
 {
     /***************************************************************************

--- a/src/swarm/client/request/model/IRequest.d
+++ b/src/swarm/client/request/model/IRequest.d
@@ -50,7 +50,7 @@ import swarm.client.request.context.RequestContext;
 
 *******************************************************************************/
 
-public abstract scope class IRequest: IFiberRequest
+public abstract class IRequest: IFiberRequest
 {
     /**************************************************************************
 

--- a/src/swarm/client/request/notifier/IRequestNotification.d
+++ b/src/swarm/client/request/notifier/IRequestNotification.d
@@ -60,7 +60,7 @@ class TypeEnum : IEnum
 
 *******************************************************************************/
 
-public scope class IRequestNotification
+public class IRequestNotification
 {
     /***************************************************************************
 
@@ -160,7 +160,7 @@ public scope class IRequestNotification
 
     ***************************************************************************/
 
-    private static immutable istring invalid_code = "INVALID";
+    private static immutable string invalid_code = "INVALID";
 
 
     /***************************************************************************

--- a/src/swarm/client/request/params/IRequestParams.d
+++ b/src/swarm/client/request/params/IRequestParams.d
@@ -266,7 +266,7 @@ public abstract class IRequestParams
                " The serialized length is not an integer multiple of 8 as " ~
                "required for alignment");
     }
-    body
+    do
     {
         return Serial!(typeof(this.tupleof)).sizeof;
     }

--- a/src/swarm/common/connection/CommandMixins.d
+++ b/src/swarm/common/connection/CommandMixins.d
@@ -41,11 +41,11 @@ public template CommandCases ( T : IEnum, size_t i = 0 )
 {
     static if ( i == T._internal_names.length )
     {
-        static immutable istring CommandCases = "";
+        static immutable string CommandCases = "";
     }
     else
     {
-        static immutable istring CommandCases = "case " ~
+        static immutable string CommandCases = "case " ~
             CTFE.toString(T._internal_values[i]) ~
             ": this.handle" ~ T._internal_names[i] ~ "(); break;" ~
             CommandCases!(T, i + 1);
@@ -68,11 +68,11 @@ public template CommandMethods ( T : IEnum, size_t i = 0 )
 {
     static if ( i == T._internal_names.length )
     {
-        static immutable istring CommandMethods = "";
+        static immutable string CommandMethods = "";
     }
     else
     {
-        static immutable istring CommandMethods =
+        static immutable string CommandMethods =
             "abstract protected void handle" ~ T._internal_names[i] ~ "();" ~
             CommandMethods!(T, i + 1);
     }

--- a/src/swarm/common/connection/ISharedResources.d
+++ b/src/swarm/common/connection/ISharedResources.d
@@ -85,7 +85,7 @@ template SharedResources_T ( T )
 
         template DeclareFreeList ( T, size_t i )
         {
-            static immutable istring DeclareFreeList = "public FreeList!("
+            static immutable string DeclareFreeList = "public FreeList!("
                 ~ typeof(T.tupleof[i]).stringof ~ ") "
                 ~ identifier!(T.tupleof[i]) ~ "_freelist;";
         }
@@ -94,11 +94,11 @@ template SharedResources_T ( T )
         {
             static if ( i == T.tupleof.length - 1 )
             {
-                static immutable istring DeclareFreeLists = DeclareFreeList!(T, i);
+                static immutable string DeclareFreeLists = DeclareFreeList!(T, i);
             }
             else
             {
-                static immutable istring DeclareFreeLists = DeclareFreeList!(T, i) ~
+                static immutable string DeclareFreeLists = DeclareFreeList!(T, i) ~
                     DeclareFreeLists!(T, i + 1);
             }
         }
@@ -120,7 +120,7 @@ template SharedResources_T ( T )
 
         template NewFreeList ( T, size_t i )
         {
-            static immutable istring NewFreeList = "this."
+            static immutable string NewFreeList = "this."
                 ~ identifier!(T.tupleof[i]) ~ "_freelist = new FreeList!("
                 ~ typeof(T.tupleof[i]).stringof ~ ");";
         }
@@ -129,11 +129,11 @@ template SharedResources_T ( T )
         {
             static if ( i == T.tupleof.length - 1 )
             {
-                static immutable istring NewFreeLists = NewFreeList!(T, i);
+                static immutable string NewFreeLists = NewFreeList!(T, i);
             }
             else
             {
-                static immutable istring NewFreeLists = NewFreeList!(T, i) ~
+                static immutable string NewFreeLists = NewFreeList!(T, i) ~
                     NewFreeLists!(T, i + 1);
             }
         }

--- a/src/swarm/common/request/model/IFiberRequest.d
+++ b/src/swarm/common/request/model/IFiberRequest.d
@@ -40,7 +40,7 @@ import swarm.protocol.FiberSelectWriter;
 
 *******************************************************************************/
 
-public abstract scope class IFiberRequest
+public abstract class IFiberRequest
 {
     /***************************************************************************
 

--- a/src/swarm/common/request/model/IRequestResources.d
+++ b/src/swarm/common/request/model/IRequestResources.d
@@ -105,7 +105,7 @@ public template IRequestResources_T ( Shared )
 
     template Getter ( T, size_t i )
     {
-        static immutable istring Getter = GetterReturnType!(T, i).stringof ~ " " ~
+        static immutable string Getter = GetterReturnType!(T, i).stringof ~ " " ~
             identifier!(T.tupleof[i]) ~ "();";
     }
 
@@ -113,11 +113,11 @@ public template IRequestResources_T ( Shared )
     {
         static if ( i == T.tupleof.length - 1 )
         {
-            static immutable istring Getters = Getter!(T, i);
+            static immutable string Getters = Getter!(T, i);
         }
         else
         {
-            static immutable istring Getters =
+            static immutable string Getters =
                 Getter!(T, i) ~ Getters!(T, i + 1);
         }
     }
@@ -203,12 +203,12 @@ public template RequestResources_T ( Shared )
     {
         static if ( isArrayType!(typeof(T.tupleof[i])) == ArrayKind.Dynamic )
         {
-            static immutable istring GetterReturnValue =
+            static immutable string GetterReturnValue =
                 "&this.acquired." ~ identifier!(T.tupleof[i]) ~ ";";
         }
         else
         {
-            static immutable istring GetterReturnValue =
+            static immutable string GetterReturnValue =
                 "this.acquired." ~ identifier!(T.tupleof[i]) ~ ";";
         }
     }
@@ -233,7 +233,7 @@ public template RequestResources_T ( Shared )
 
     template Getter ( T, size_t i )
     {
-        static immutable istring Getter =
+        static immutable string Getter =
             GetterReturnType!(T, i).stringof ~ " " ~ identifier!(T.tupleof[i]) ~ "()" ~
             "{" ~
                 "if(!this.acquired." ~ identifier!(T.tupleof[i]) ~ ")" ~
@@ -252,11 +252,11 @@ public template RequestResources_T ( Shared )
     {
         static if ( i == T.tupleof.length - 1 )
         {
-            static immutable istring Getters = Getter!(T, i);
+            static immutable string Getters = Getter!(T, i);
         }
         else
         {
-            static immutable istring Getters = Getter!(T, i) ~ Getters!(T, i + 1);
+            static immutable string Getters = Getter!(T, i) ~ Getters!(T, i + 1);
         }
     }
 
@@ -279,7 +279,7 @@ public template RequestResources_T ( Shared )
 
     template Newer ( T, size_t i )
     {
-        static immutable istring Newer = "protected abstract " ~ typeof(T.tupleof[i]).stringof ~ " " ~
+        static immutable string Newer = "protected abstract " ~ typeof(T.tupleof[i]).stringof ~ " " ~
             "new_" ~ identifier!(T.tupleof[i]) ~ "();";
     }
 
@@ -287,11 +287,11 @@ public template RequestResources_T ( Shared )
     {
         static if ( i == T.tupleof.length - 1 )
         {
-            static immutable istring Newers = Newer!(T, i);
+            static immutable string Newers = Newer!(T, i);
         }
         else
         {
-            static immutable istring Newers = Newer!(T, i) ~ Newers!(T, i + 1);
+            static immutable string Newers = Newer!(T, i) ~ Newers!(T, i + 1);
         }
     }
 
@@ -321,14 +321,14 @@ public template RequestResources_T ( Shared )
     {
         static if ( isArrayType!(typeof(T.tupleof[i])) == ArrayKind.Dynamic )
         {
-            static immutable istring Initialiser =
+            static immutable string Initialiser =
                 "protected void " ~
                 "init_" ~ identifier!(T.tupleof[i]) ~ "(ref " ~ typeof(T.tupleof[i]).stringof ~ " f)" ~
                 "{f.length=0; assumeSafeAppend(f);}";
         }
         else
         {
-            static immutable istring Initialiser =
+            static immutable string Initialiser =
                 "protected void " ~
                 "init_" ~ identifier!(T.tupleof[i]) ~ "(" ~ typeof(T.tupleof[i]).stringof ~ "){}";
         }
@@ -338,11 +338,11 @@ public template RequestResources_T ( Shared )
     {
         static if ( i == T.tupleof.length - 1 )
         {
-            static immutable istring Initialisers = Initialiser!(T, i);
+            static immutable string Initialisers = Initialiser!(T, i);
         }
         else
         {
-            static immutable istring Initialisers =
+            static immutable string Initialisers =
                 Initialiser!(T, i) ~ Initialisers!(T, i + 1);
         }
     }
@@ -364,7 +364,7 @@ public template RequestResources_T ( Shared )
 
     template Recycler ( T, size_t i )
     {
-        static immutable istring Recycler =
+        static immutable string Recycler =
             "if(this.acquired." ~ identifier!(T.tupleof[i]) ~ ")" ~
             "{" ~
                 "this.shared_resources." ~ identifier!(T.tupleof[i]) ~ "_freelist" ~
@@ -376,11 +376,11 @@ public template RequestResources_T ( Shared )
     {
         static if ( i == T.tupleof.length - 1 )
         {
-            static immutable istring Recyclers = Recycler!(T, i);
+            static immutable string Recyclers = Recycler!(T, i);
         }
         else
         {
-            static immutable istring Recyclers = Recycler!(T, i) ~ Recyclers!(T, i + 1);
+            static immutable string Recyclers = Recycler!(T, i) ~ Recyclers!(T, i + 1);
         }
     }
 
@@ -393,7 +393,7 @@ public template RequestResources_T ( Shared )
 
     ***************************************************************************/
 
-    abstract scope class RequestResources : IRequestResources
+    abstract class RequestResources : IRequestResources
     {
         /***********************************************************************
 
@@ -495,7 +495,7 @@ version ( unittest )
 
 unittest
 {
-    scope class Resources : LocalNamespace.RequestResources
+    class Resources : LocalNamespace.RequestResources
     {
         this ()
         {

--- a/src/swarm/neo/authentication/CredentialsFile.d
+++ b/src/swarm/neo/authentication/CredentialsFile.d
@@ -82,7 +82,7 @@ extern (C) private int g_ascii_xdigit_value ( char c ); // glib-2.0
 
 ***************************************************************************/
 
-public HmacDef.Key[istring] parse ( cstring filepath )
+public HmacDef.Key[string] parse ( cstring filepath )
 {
     scope file = new File(filepath, File.ReadExisting);
     scope ( exit ) file.close;
@@ -125,7 +125,7 @@ public HmacDef.Key[istring] parse ( cstring filepath )
 
 ***************************************************************************/
 
-private HmacDef.Key[istring] parseContent ( istring content,
+private HmacDef.Key[string] parseContent ( string content,
     cstring filepath = null )
 {
     int line = 0; // The current line in the input file.
@@ -138,7 +138,7 @@ private HmacDef.Key[istring] parseContent ( istring content,
 
     ***********************************************************************/
 
-    void enforce ( bool ok, cstring msg_base, istring src_file = __FILE__,
+    void enforce ( bool ok, cstring msg_base, string src_file = __FILE__,
         typeof(__LINE__) src_line = __LINE__ )
     {
         if (!ok)
@@ -150,7 +150,7 @@ private HmacDef.Key[istring] parseContent ( istring content,
 
     scope parser = new QueryParams('\n', ':');
 
-    HmacDef.Key[istring] keys;
+    HmacDef.Key[string] keys;
 
     foreach (name, hex_key; parser.set(content))
     {
@@ -192,7 +192,7 @@ private HmacDef.Key[istring] parseContent ( istring content,
         assert(i == hex_key.length); // enforced above
 
         /*
-         * name is a cstring slice to the istring content so we don't need
+         * name is a cstring slice to the string content so we don't need
          * to idup it in order to use it as an associative array key. Verify
          * the slice is correct, and cast it.
          * Note that determining that name is a slice to content via pointer
@@ -202,10 +202,10 @@ private HmacDef.Key[istring] parseContent ( istring content,
          * inherits in this case. However, there is no other way, and x86-64
          * has a flat memory model.
          */
-        static assert(is(typeof(content) == istring));
+        static assert(is(typeof(content) == string));
         verify(content.ptr <= name.ptr &&
                name.ptr + name.length <= content.ptr + content.length);
-        keys[cast(istring)name] = key;
+        keys[cast(string)name] = key;
     }
 
     return keys.rehash;
@@ -236,7 +236,7 @@ public class CredentialsParseException: Exception
     ***********************************************************************/
 
     public this ( cstring msg_base, cstring reg_file, uint reg_file_line,
-        istring src_file = __FILE__, typeof(__LINE__) src_line = __LINE__ )
+        string src_file = __FILE__, typeof(__LINE__) src_line = __LINE__ )
     {
         super(format("{} in registry file {} at line {}", msg_base, file, reg_file_line));
     }
@@ -262,8 +262,8 @@ version ( unittest )
 
     ***************************************************************************/
 
-    void registryTest ( istring name, istring file_content,
-        HmacDef.Key[istring] expected )
+    void registryTest ( string name, string file_content,
+        HmacDef.Key[string] expected )
     {
         auto t = new NamedTest(name);
         auto reg = parseContent(file_content, name);
@@ -311,7 +311,7 @@ version ( unittest )
 unittest
 {
     // Empty
-    registryTest("Empty", [], (HmacDef.Key[istring]).init);
+    registryTest("Empty", [], (HmacDef.Key[string]).init);
 
     // One entry then EOF
     registryTest(

--- a/src/swarm/neo/authentication/HmacAuthCode.d
+++ b/src/swarm/neo/authentication/HmacAuthCode.d
@@ -295,8 +295,8 @@ struct HmacAuthCode
 
         ***********************************************************************/
 
-        this ( uint gcry_error_code, istring funcname,
-               istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+        this ( uint gcry_error_code, string funcname,
+               string file = __FILE__, typeof(__LINE__) line = __LINE__ )
         {
             auto msg = "(no error description available)"[];
 

--- a/src/swarm/neo/authentication/NodeCredentials.d
+++ b/src/swarm/neo/authentication/NodeCredentials.d
@@ -29,7 +29,7 @@ public class Credentials
 
     ***************************************************************************/
 
-    private HmacDef.Key[istring] credentials_;
+    private HmacDef.Key[string] credentials_;
 
     /***************************************************************************
 
@@ -37,7 +37,7 @@ public class Credentials
 
     ***************************************************************************/
 
-    private istring filepath;
+    private string filepath;
 
     /***************************************************************************
 
@@ -52,7 +52,7 @@ public class Credentials
 
     ***************************************************************************/
 
-    public this ( istring filepath )
+    public this ( string filepath )
     {
         this.filepath = filepath;
         this.update();
@@ -68,7 +68,7 @@ public class Credentials
 
     ***************************************************************************/
 
-    public const(HmacDef.Key[istring])* credentials ( )
+    public const(HmacDef.Key[string])* credentials ( )
     {
         return &this.credentials_;
     }

--- a/src/swarm/neo/client/Connection.d
+++ b/src/swarm/neo/client/Connection.d
@@ -187,7 +187,7 @@ public final class Connection: ConnectionBase
 
     static class ConnectionClosedException : Exception
     {
-        this ( istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+        this ( string file = __FILE__, typeof(__LINE__) line = __LINE__ )
         {
             super("Connection closed", file, line);
         }
@@ -298,7 +298,7 @@ public final class Connection: ConnectionBase
 
     ***************************************************************************/
 
-    public void shutdownAndHalt ( istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+    public void shutdownAndHalt ( string file = __FILE__, typeof(__LINE__) line = __LINE__ )
     {
         this.restart_after_shutdown = false;
 

--- a/src/swarm/neo/client/ConnectionSet.d
+++ b/src/swarm/neo/client/ConnectionSet.d
@@ -343,7 +343,7 @@ public final class ConnectionSet : RequestOnConn.IConnectionGetter
 
     ***************************************************************************/
 
-    public void stopAll ( istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+    public void stopAll ( string file = __FILE__, typeof(__LINE__) line = __LINE__ )
     {
         this.epoll.unregister(this.yielded_rqonconns);
 

--- a/src/swarm/neo/client/NotifierTypes.d
+++ b/src/swarm/neo/client/NotifierTypes.d
@@ -136,7 +136,7 @@ public struct RequestNodeUnsupportedInfo
 
     ***************************************************************************/
 
-    private istring type_explanation ( )
+    private string type_explanation ( )
     {
         with ( Type ) final switch ( this.type )
         {

--- a/src/swarm/neo/client/RequestOnConn.d
+++ b/src/swarm/neo/client/RequestOnConn.d
@@ -394,7 +394,7 @@ public class RequestOnConn: RequestOnConnBase, IRequestOnConn
 
         ***********************************************************************/
 
-        public Exception opCall ( AbortReason reason, istring file = __FILE__,
+        public Exception opCall ( AbortReason reason, string file = __FILE__,
             long line = __LINE__ )
         {
             this.reason = reason;

--- a/src/swarm/neo/client/RequestSet.d
+++ b/src/swarm/neo/client/RequestSet.d
@@ -608,7 +608,7 @@ public final class RequestSet: IRequestSet
         {
             assert(this); // invariant
         }
-        body
+        do
         {
             this.id = 0;
             this.request_on_conns.reset(&this.outer.request_on_conn_pool.recycle);
@@ -926,7 +926,7 @@ public final class RequestSet: IRequestSet
     {
         assert((id in this.active_requests) is null);
     }
-    body
+    do
     {
         if ( auto rq = id in this.active_requests )
         {
@@ -1022,7 +1022,7 @@ public final class RequestSet: IRequestSet
     {
         assert(request.id);
     }
-    body
+    do
     {
         if ( this.active_requests.length < typeof(this).max_requests )
         {
@@ -1105,7 +1105,7 @@ public final class RequestSet: IRequestSet
 
     static class NoMoreRequests: Exception
     {
-        this ( istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+        this ( string file = __FILE__, typeof(__LINE__) line = __LINE__ )
         {
             super("Attepted to start more than " ~ max_requests.stringof ~
                   " requests, which is the maximum allowed number", file, line);

--- a/src/swarm/neo/client/mixins/AllNodesRequestCore.d
+++ b/src/swarm/neo/client/mixins/AllNodesRequestCore.d
@@ -215,7 +215,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         private RequestOnConn.EventDispatcherAllNodes conn;
         private ExampleRequest.Context* context;
@@ -304,7 +304,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         private RequestOnConn.EventDispatcherAllNodes conn;
 
@@ -474,7 +474,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         import swarm.neo.connection.RequestOnConnBase;
 

--- a/src/swarm/neo/client/mixins/BatchRequestCore.d
+++ b/src/swarm/neo/client/mixins/BatchRequestCore.d
@@ -88,7 +88,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         private RequestOnConn.EventDispatcherAllNodes conn;
         private ExampleRequest.Context* context;
@@ -135,7 +135,7 @@ public template BatchController ( Request, IController )
 
     ***************************************************************************/
 
-    public scope class Controller : IController
+    public class Controller : IController
     {
         import ocean.core.Enforce;
         import swarm.neo.client.mixins.RequestCore : ControllerBase;

--- a/src/swarm/neo/client/mixins/ClientCore.d
+++ b/src/swarm/neo/client/mixins/ClientCore.d
@@ -86,10 +86,10 @@ template ClientCore ( )
         import ocean.util.config.ConfigFiller : Required;
 
         /// Path of file specifying the addr/port of all nodes to connect with.
-        public Required!(istring) nodes_file;
+        public Required!(string) nodes_file;
 
         /// Path of file containing the client's auth name/key.
-        public Required!(istring) credentials_file;
+        public Required!(string) credentials_file;
     }
 
     /// Compile-time-configurable settings to be passed to the ctor.
@@ -180,7 +180,7 @@ template ClientCore ( )
     {
         AddrPort ip;
         auto addr_ok = ip.setAddress(host);
-        enforce(addr_ok, cast(istring)("Invalid address: " ~ host));
+        enforce(addr_ok, cast(string)("Invalid address: " ~ host));
         ip.port = port;
         this.connections.start(ip);
     }
@@ -590,7 +590,7 @@ template ClientCore ( )
 
         Params:
             Requests = tuple of request names. All elements must be implicitly
-                castable to istring
+                castable to string
 
     ***************************************************************************/
 
@@ -621,7 +621,7 @@ template ClientCore ( )
 
         ***********************************************************************/
 
-        public IRequestStats.RequestStats request ( istring name ) ( )
+        public IRequestStats.RequestStats request ( string name ) ( )
         {
             mixin("alias Internals." ~ name ~ " Request;");
             return this.outer.connections.request_set.stats.requestStats(
@@ -645,7 +645,7 @@ template ClientCore ( )
 
         ***********************************************************************/
 
-        public bool requestHasOccurred ( istring name ) ( )
+        public bool requestHasOccurred ( string name ) ( )
         {
             mixin("alias Internals." ~ name ~ " Request;");
             return this.outer.connections.request_set.stats.requestHasOccurred(
@@ -674,13 +674,13 @@ template ClientCore ( )
 
             *******************************************************************/
 
-            public int opApply ( scope int delegate ( ref istring request_name,
+            public int opApply ( scope int delegate ( ref string request_name,
                 ref IRequestStats.RequestStats request_stats ) dg )
             {
                 int res;
                 foreach ( rq_name; Requests )
                 {
-                    static assert(is(typeof(rq_name) : istring));
+                    static assert(is(typeof(rq_name) : string));
 
                     auto slice = rq_name[];
                     if ( !this.occurred_only ||
@@ -792,7 +792,7 @@ template ClientCore ( )
 
     ***************************************************************************/
 
-    public void shutdown ( istring file = __FILE__, typeof(__LINE__) line = __LINE__ )
+    public void shutdown ( string file = __FILE__, typeof(__LINE__) line = __LINE__ )
     {
         this.connections.stopAll(file, line);
     }

--- a/src/swarm/neo/client/mixins/SuspendableRequestCore.d
+++ b/src/swarm/neo/client/mixins/SuspendableRequestCore.d
@@ -141,7 +141,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         private RequestOnConn.EventDispatcherAllNodes conn;
         private ExampleRequest.Context* context;
@@ -357,7 +357,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         import swarm.neo.connection.RequestOnConnBase;
 
@@ -445,7 +445,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         import swarm.neo.connection.RequestOnConnBase;
 
@@ -514,7 +514,7 @@ public template SuspendableController ( Request, IController, MessageType )
 
     ***************************************************************************/
 
-    public scope class Controller : IController
+    public class Controller : IController
     {
         import ocean.core.Enforce;
         import ocean.core.Verify;
@@ -911,7 +911,7 @@ unittest
 
     // (Partial) request implementation, to be instantiated from the request's
     // handler function.
-    scope class ExampleRequestImpl
+    class ExampleRequestImpl
     {
         import swarm.neo.util.MessageFiber;
         import swarm.neo.request.RequestEventDispatcher;

--- a/src/swarm/neo/client/request_options/RequestOptions.d
+++ b/src/swarm/neo/client/request_options/RequestOptions.d
@@ -246,7 +246,7 @@ private template getHandlerArgument ( Handler, Handlers ... )
 
 *******************************************************************************/
 
-private istring assertArgsHandled ( size_t n_args, ArgsAndHandlers ... ) ( )
+private string assertArgsHandled ( size_t n_args, ArgsAndHandlers ... ) ( )
 {
     mstring duplicate, unhandled;
 

--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -361,7 +361,7 @@ abstract class ConnectionBase: ISelectClient
         {
             assert(false);
         }
-        body
+        do
         {
             this.loop_started = true;
             scope (exit)
@@ -1003,7 +1003,7 @@ abstract class ConnectionBase: ISelectClient
         Params:
             e          = the exception reflecting the error
             request_id = the id of the request whose handler calls this method
-                         and should not receive a shutdown notification or 0 if 
+                         and should not receive a shutdown notification or 0 if
                          not calling from a request handler
 
         In:

--- a/src/swarm/neo/connection/RequestOnConnBase.d
+++ b/src/swarm/neo/connection/RequestOnConnBase.d
@@ -357,7 +357,7 @@ abstract class RequestOnConnBase
 
         ***********************************************************************/
 
-        public scope class Payload
+        public class Payload
         {
             import ocean.meta.traits.Indirections : hasIndirections;
 
@@ -543,7 +543,7 @@ abstract class RequestOnConnBase
         ***********************************************************************/
 
         public void shutdownWithProtocolError ( cstring msg,
-            istring file = __FILE__, int line = __LINE__ )
+            string file = __FILE__, int line = __LINE__ )
         {
             auto e = this.outer.connection.protocol_error.set(msg, file, line);
             this.shutdownConnection(e);
@@ -651,7 +651,7 @@ abstract class RequestOnConnBase
             assert(fired_event_non_const.active !=
                 fired_event_non_const.active.none);
         }
-        body
+        do
         {
             EventNotification fired_event;
 

--- a/src/swarm/neo/connection/YieldedRequestOnConns.d
+++ b/src/swarm/neo/connection/YieldedRequestOnConns.d
@@ -217,7 +217,7 @@ class YieldedRequestOnConns: ISelectEvent
                    ".swapAndPop: " ~
                    "Expected the inactive queue to be empty when returning");
         }
-        body
+        do
         {
             verify(this.queue[!this.active].is_empty, typeof(this).stringof ~
                    ".swapAndPop: " ~

--- a/src/swarm/neo/node/Connection.d
+++ b/src/swarm/neo/node/Connection.d
@@ -93,7 +93,7 @@ class Connection: ConnectionBase
 
     ***************************************************************************/
 
-    public this ( ref const(Key[istring]) credentials,
+    public this ( ref const(Key[string]) credentials,
                   AddressIPSocket!() socket, EpollSelectDispatcher epoll,
                   scope RequestSet.Handler request_handler,
                   scope void delegate ( ) when_closed, RequestPool request_pool,

--- a/src/swarm/neo/node/ConnectionHandler.d
+++ b/src/swarm/neo/node/ConnectionHandler.d
@@ -75,7 +75,7 @@ class ConnectionHandler : IConnectionHandler
         public struct RequestInfo
         {
             /// The name of the request, used for stats tracking.
-            istring name;
+            string name;
 
             /// The ClassInfo of the request handler class that is newed when
             /// handling a request of this type.
@@ -111,7 +111,7 @@ class ConnectionHandler : IConnectionHandler
 
         public void addHandler ( Request : IRequest ) ( )
         {
-            static void memberExists ( istring name, T ) ( )
+            static void memberExists ( string name, T ) ( )
             {
                 static assert (
                     hasMember!(Request, name)
@@ -120,7 +120,7 @@ class ConnectionHandler : IConnectionHandler
                     ~ name ~ "' of type '" ~ T.stringof ~ "'.");
             }
 
-            memberExists!("name", istring);
+            memberExists!("name", string);
             memberExists!("command", Command);
             memberExists!("timing", bool);
             memberExists!("scheduled_for_removal", bool);
@@ -207,7 +207,7 @@ class ConnectionHandler : IConnectionHandler
 
         ***********************************************************************/
 
-        public const(Key[istring])* credentials;
+        public const(Key[string])* credentials;
 
         /***********************************************************************
 
@@ -280,7 +280,7 @@ class ConnectionHandler : IConnectionHandler
 
         public this ( EpollSelectDispatcher epoll,
             RequestMap requests, bool no_delay,
-            ref const(Key[istring]) credentials, INodeInfo node_info,
+            ref const(Key[string]) credentials, INodeInfo node_info,
             scope GetResourceAcquirerDg get_resource_acquirer )
         {
             verify(requests.supported_requests.length > 0);
@@ -642,7 +642,7 @@ unittest
     class Rq1_v0 : IRequest
     {
         static immutable Command command = Command(1, 0);
-        static immutable istring name = "Request1";
+        static immutable string name = "Request1";
         static immutable bool timing = true;
         static immutable bool scheduled_for_removal = false;
         void handle ( RequestOnConn connection, Object resources,
@@ -652,7 +652,7 @@ unittest
     class Rq1_v1 : IRequest
     {
         static immutable Command command = Command(1, 1);
-        static immutable istring name = "Request1";
+        static immutable string name = "Request1";
         static immutable bool timing = true;
         static immutable bool scheduled_for_removal = false;
         void handle ( RequestOnConn connection, Object resources,

--- a/src/swarm/neo/node/RequestSet.d
+++ b/src/swarm/neo/node/RequestSet.d
@@ -146,7 +146,7 @@ class RequestSet
         {
             assert(name.length > 0);
         }
-        body
+        do
         {
             auto node_conn = downcast!(Connection)(this.connection);
             verify(node_conn !is null);
@@ -477,7 +477,7 @@ class RequestSet
         assert(request.id == id);
         assert(this.n_active_requests <= max_requests);
     }
-    body
+    do
     {
         bool added;
         auto request = this.active_requests.put(

--- a/src/swarm/neo/protocol/Message.d
+++ b/src/swarm/neo/protocol/Message.d
@@ -136,7 +136,7 @@ align(1) struct MessageHeader
     {
         assert(!this.total_parity);
     }
-    body
+    do
     {
         return this.parity = this.calcParity();
     }

--- a/src/swarm/neo/protocol/ProtocolError.d
+++ b/src/swarm/neo/protocol/ProtocolError.d
@@ -43,7 +43,7 @@ class ProtocolError: Exception
     ***************************************************************************/
 
     public typeof(this) setFmt
-        ( istring file = __FILE__, typeof(__LINE__) line = __LINE__, T ... )
+        ( string file = __FILE__, typeof(__LINE__) line = __LINE__, T ... )
         ( cstring fmt, T items )
     {
         static if (items.length)
@@ -72,7 +72,7 @@ class ProtocolError: Exception
     ***************************************************************************/
 
     public void enforceFmt
-        ( istring file = __FILE__, long line = __LINE__, Ok, T ... )
+        ( string file = __FILE__, long line = __LINE__, Ok, T ... )
         ( Ok ok, cstring fmt, T params )
     {
         if (!ok)
@@ -90,7 +90,7 @@ class ProtocolError: Exception
 
     ***************************************************************************/
 
-    private void setFmt_ ( T... ) ( istring file, long line, cstring fmt, T args )
+    private void setFmt_ ( T... ) ( string file, long line, cstring fmt, T args )
     {
         this.reused_msg.reset();
         sformat(this.reused_msg, fmt, args);

--- a/src/swarm/neo/protocol/connect/ConnectProtocol.d
+++ b/src/swarm/neo/protocol/connect/ConnectProtocol.d
@@ -217,7 +217,7 @@ class ConnectProtocol: ISelectClient
 
     public void checkVersion (
         ubyte client_protocol_version, ubyte node_protocol_version,
-        istring file = __FILE__, typeof(__LINE__) line = __LINE__
+        string file = __FILE__, typeof(__LINE__) line = __LINE__
     )
     {
         if (client_protocol_version != node_protocol_version)

--- a/src/swarm/neo/protocol/connect/NodeConnect.d
+++ b/src/swarm/neo/protocol/connect/NodeConnect.d
@@ -58,7 +58,7 @@ class NodeConnect
 
     ***************************************************************************/
 
-    private const(HmacDef.Key[istring])* credentials;
+    private const(HmacDef.Key[string])* credentials;
 
     /***************************************************************************
 
@@ -89,7 +89,7 @@ class NodeConnect
 
     ***************************************************************************/
 
-    public this ( ref const(HmacDef.Key[istring]) credentials )
+    public this ( ref const(HmacDef.Key[string]) credentials )
     {
         this.credentials = &credentials;
         this.e_auth_rejected = new HmacAuthCode.RejectedException;

--- a/src/swarm/neo/protocol/socket/IOStats.d
+++ b/src/swarm/neo/protocol/socket/IOStats.d
@@ -44,4 +44,3 @@ struct IOStats
 
     public uint num_iowait_calls;
 }
-

--- a/src/swarm/neo/protocol/socket/MessageGenerator.d
+++ b/src/swarm/neo/protocol/socket/MessageGenerator.d
@@ -236,7 +236,7 @@ struct IoVecTracker
             with (this.fields[0]) assert(iov_base[0 .. iov_len] is dst);
         }
     }
-    body
+    do
     {
         if (this.length)
         {
@@ -356,4 +356,3 @@ struct IoVecTracker
         with (iov.fields[0]) test(iov_base[0 .. iov_len] is buf);
     }
 }
-

--- a/src/swarm/neo/protocol/socket/MessageReceiver.d
+++ b/src/swarm/neo/protocol/socket/MessageReceiver.d
@@ -148,7 +148,7 @@ private class MessageReceiverBase
     {
         assert(!this.buffer_content_end);
     }
-    body
+    do
     {
         verify(!this.buffer_content_end);
 
@@ -299,7 +299,7 @@ private class MessageReceiverBase
     {
         assert(this.buffer_content_end >= header.sizeof + header.body_length);
     }
-    body
+    do
     {
         /*
          * this.buffer[0 .. this.buffer_content_end] contains a partial message,
@@ -391,7 +391,7 @@ private class MessageReceiverBase
         assert(bytes_requested <= this.buffer_content_end);
         assert(this); // invariant
     }
-    body
+    do
     {
         if (this.buffer_content_end < bytes_requested)
         {
@@ -522,7 +522,7 @@ class MessageReceiver: MessageReceiverBase
     {
         assert(this);
     }
-    body
+    do
     {
         verify((events & events.EPOLLIN) != 0,
                typeof(this).stringof ~ ".write: called without EPOLLIN event");
@@ -661,7 +661,7 @@ unittest
         {
             checkMsgBody(dst[MessageHeader.sizeof .. $], id);
         }
-        body
+        do
         {
             verify(dst.length >= MessageHeader.sizeof + Info.sizeof);
 

--- a/src/swarm/neo/protocol/socket/MessageSender.d
+++ b/src/swarm/neo/protocol/socket/MessageSender.d
@@ -200,7 +200,7 @@ class MessageSender
     {
         assert(!this.pending_data.length);
     }
-    body
+    do
     {
         verify(this.pending_data.length > 0, typeof(this).stringof ~
                ".finishSending: no message to send");
@@ -249,7 +249,7 @@ class MessageSender
     {
         assert(need_finish || !this.pending_data.length);
     }
-    body
+    do
     {
         verify(src.length > 0, typeof(this).stringof ~ ".assign_: empty message");
         verify(!this.pending_data.length, typeof(this).stringof ~

--- a/src/swarm/neo/request/RequestEventDispatcher.d
+++ b/src/swarm/neo/request/RequestEventDispatcher.d
@@ -801,7 +801,7 @@ public struct RequestEventDispatcher
         auto waiting_fiber = cast(WaitingFiber)const_waiting_fiber;
         assert(waiting_fiber.event.active == waiting_fiber.event.active.send);
     }
-    body
+    do
     {
         verify(this.waiting_fibers.length > 0);
         verify(this.enabled_events > 0);
@@ -832,7 +832,7 @@ public struct RequestEventDispatcher
     {
         assert(this.queued_signals.length == 0);
     }
-    body
+    do
     {
         while ( this.queued_signals.length > 0 )
         {

--- a/src/swarm/neo/util/Batch.d
+++ b/src/swarm/neo/util/Batch.d
@@ -273,7 +273,7 @@ public struct BatchWriter ( Record ... )
 
 *******************************************************************************/
 
-public scope class BatchReader ( Record ... )
+public class BatchReader ( Record ... )
 {
     import ocean.core.Enforce;
 
@@ -460,7 +460,7 @@ version ( unittest )
     }
 
     /// Adds the specified field to the batch and checks the result.
-    void checkAdd ( Field ) ( istring test_name, BatchWriter!(Field) batch,
+    void checkAdd ( Field ) ( string test_name, BatchWriter!(Field) batch,
         Field field, size_t expected_length,
         ExpectedResult expected = ExpectedResult.Added )
     {
@@ -601,7 +601,7 @@ unittest
     struct KeyValue
     {
         hash_t key;
-        istring value;
+        string value;
     }
     KeyValue[] values = [KeyValue(12, "hi"), KeyValue(23, "bye"),
         KeyValue(34, "whatever")];

--- a/src/swarm/neo/util/FiberTokenHashGenerator.d
+++ b/src/swarm/neo/util/FiberTokenHashGenerator.d
@@ -58,7 +58,7 @@ struct FiberTokenHashGenerator
             assert(!this.receiving);
         }
     }
-    body
+    do
     {
         this.hash = rand();
 

--- a/src/swarm/neo/util/MessageFiber.d
+++ b/src/swarm/neo/util/MessageFiber.d
@@ -85,7 +85,7 @@ public class OceanMessageFiber
 
         ***********************************************************************/
 
-        private debug (MessageFiberToken) istring str;
+        private debug (MessageFiberToken) string str;
 
         /***********************************************************************
 
@@ -107,7 +107,7 @@ public class OceanMessageFiber
 
         ***********************************************************************/
 
-        public static Token opCall ( istring s )
+        public static Token opCall ( string s )
         {
             Token token;
             token.hash = Fnv1a64(s);
@@ -170,7 +170,7 @@ public class OceanMessageFiber
     {
         this ( )  {super("Fiber killed");}
 
-        void set ( istring file, long line )
+        void set ( string file, long line )
         {
             super.file = file;
             super.line = line;
@@ -188,7 +188,7 @@ public class OceanMessageFiber
     {
         this ( )  {super("Resumed with invalid identifier!");}
 
-        ResumeException set ( istring file, long line )
+        ResumeException set ( string file, long line )
         {
             super.file = file;
             super.line = line;
@@ -385,7 +385,7 @@ public class OceanMessageFiber
         assert (a);
         assert (a != a.exc);
     }
-    body
+    do
     {
         verify (this.fiber.state != this.fiber.State.EXEC, "attempt to start an active fiber");
 
@@ -443,7 +443,7 @@ public class OceanMessageFiber
         auto msg_out = cast(Unqual!(typeof(_msg_out))) _msg_out;
         assert(msg_out.active);
     }
-    body
+    do
     {
         verify (this.fiber.state == this.fiber.State.EXEC, "attempt to suspend an inactive fiber");
         with (msg) if (active == active.exc) verify (exc !is null);
@@ -549,7 +549,7 @@ public class OceanMessageFiber
         assert (a);
         assert (a != a.exc);
     }
-    body
+    do
     {
         verify (this.fiber.state == this.fiber.State.HOLD, "attempt to resume a non-held fiber");
 
@@ -617,7 +617,7 @@ public class OceanMessageFiber
 
      **************************************************************************/
 
-    public void kill ( istring file = __FILE__, long line = __LINE__ )
+    public void kill ( string file = __FILE__, long line = __LINE__ )
     {
         verify (this.fiber.state == this.fiber.State.HOLD, "attempt to kill a non-held fiber");
         verify (!this.killed);

--- a/src/swarm/neo/util/TreeMap.d
+++ b/src/swarm/neo/util/TreeMap.d
@@ -555,7 +555,7 @@ struct TreeMap ( Node = eb64_node )
             }
             else
             {
-                enum istring msg = "malloc(" ~ Node.sizeof.stringof ~
+                enum string msg = "malloc(" ~ Node.sizeof.stringof ~
                                    ") failed: Out of memory\n\0";
                 fputs(msg.ptr, stderr);
                 exit(EXIT_FAILURE);

--- a/src/swarm/neo/util/TreeQueue.d
+++ b/src/swarm/neo/util/TreeQueue.d
@@ -384,7 +384,7 @@ private struct TreeQueueCore
     {
         assert(!this.ebtree.is_empty, "ebtree empty after push");
     }
-    body
+    do
     {
         bool added;
         auto item = this.ebtree.put(id, added);

--- a/src/swarm/neo/util/Util.d
+++ b/src/swarm/neo/util/Util.d
@@ -79,7 +79,7 @@ void appendSlices ( Types ... ) ( ref void[][] slices, ref Types x )
     }
 }
 
-char[] TupleToSlices ( Types ... ) ( istring name )
+char[] TupleToSlices ( Types ... ) ( string name )
 {
     char[] code;
 

--- a/src/swarm/node/model/IChannelsNodeInfo.d
+++ b/src/swarm/node/model/IChannelsNodeInfo.d
@@ -71,7 +71,7 @@ public interface IChannelsNodeInfo : INodeInfo
     public IStorageEngineInfo* opIn_r ( cstring id );
 
 
-    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+    public alias opBinaryRight ( string op : "in" ) = opIn_r;
 
 
     /***************************************************************************
@@ -112,7 +112,7 @@ version ( unittest )
 
         ***********************************************************************/
 
-        istring storage_type_ = "dummy";
+        string storage_type_ = "dummy";
         ulong num_records_;
         ulong num_bytes_;
 
@@ -130,7 +130,7 @@ version ( unittest )
 
             *******************************************************************/
 
-            istring id_;
+            string id_;
             ulong num_records_;
             ulong num_bytes_;
 
@@ -143,7 +143,7 @@ version ( unittest )
 
             *******************************************************************/
 
-            this ( istring id )
+            this ( string id )
             {
                 this.id_ = id;
             }
@@ -170,7 +170,7 @@ version ( unittest )
             }
         }
 
-        ChannelStats[istring] channels;
+        ChannelStats[string] channels;
 
         /***********************************************************************
 
@@ -186,8 +186,8 @@ version ( unittest )
 
         ***********************************************************************/
 
-        this ( istring[] actions, istring[] requests, istring[] neo_requests,
-            istring[] channels, istring[] disable_timing )
+        this ( string[] actions, string[] requests, string[] neo_requests,
+            string[] channels, string[] disable_timing )
         {
             super(actions, requests, neo_requests, disable_timing);
 

--- a/src/swarm/node/model/INodeInfo.d
+++ b/src/swarm/node/model/INodeInfo.d
@@ -238,8 +238,8 @@ version ( unittest )
 
         ***********************************************************************/
 
-        this ( istring[] actions, istring[] requests, istring[] neo_requests,
-            istring[] disable_timing )
+        this ( string[] actions, string[] requests, string[] neo_requests,
+            string[] disable_timing )
         {
             this.record_action_counters_ = new RecordActionCounters(actions);
             this.request_stats_ = new RequestStats;

--- a/src/swarm/node/model/NeoChannelsNode.d
+++ b/src/swarm/node/model/NeoChannelsNode.d
@@ -218,7 +218,7 @@ public class ChannelsNodeBase (
 
     /** ditto */
 
-    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+    public alias opBinaryRight ( string op : "in" ) = opIn_r;
 
 
     /***************************************************************************

--- a/src/swarm/node/model/NeoNode.d
+++ b/src/swarm/node/model/NeoNode.d
@@ -571,7 +571,7 @@ public abstract class INodeBase : INode, INodeInfo
 
     ***************************************************************************/
 
-    protected istring[] record_action_counter_ids ( )
+    protected string[] record_action_counter_ids ( )
     {
         return null;
     }
@@ -676,7 +676,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
         ***********************************************************************/
 
-        public istring unix_socket_path;
+        public string unix_socket_path;
 
         /***********************************************************************
 
@@ -686,7 +686,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
         ***********************************************************************/
 
-        public istring credentials_filename;
+        public string credentials_filename;
 
         /***********************************************************************
 
@@ -695,7 +695,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
         ***********************************************************************/
 
-        public Key[istring] credentials_map;
+        public Key[string] credentials_map;
     }
 
     /***************************************************************************
@@ -722,7 +722,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
     ***************************************************************************/
 
-    protected BasicCommandHandler.Handler[istring] unix_socket_handlers;
+    protected BasicCommandHandler.Handler[string] unix_socket_handlers;
 
     /***************************************************************************
 
@@ -779,7 +779,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
         this.neo_socket = new AddressIPSocket!();
 
         // Load credentials from specified file.
-        const(Key[istring])* credentials;
+        const(Key[string])* credentials;
         if ( options.credentials_filename )
         {
             verify(options.credentials_map is null);
@@ -794,7 +794,7 @@ public class NodeBase ( ConnHandler : ISwarmConnectionHandler ) : INodeBase
 
             // Make sure the reference to the credentials map does not go out
             // of scope. (Store a copy in heap-allocated memory.)
-            static struct S { Key[istring] cred; }
+            static struct S { Key[string] cred; }
             auto s = new S;
             s.cred = options.credentials_map;
             credentials = &s.cred;

--- a/src/swarm/node/model/RecordActionCounters.d
+++ b/src/swarm/node/model/RecordActionCounters.d
@@ -52,7 +52,7 @@ public class RecordActionCounters
 
     ***************************************************************************/
 
-    private Counter[istring] counters;
+    private Counter[string] counters;
 
     /***************************************************************************
 
@@ -136,7 +136,7 @@ public class RecordActionCounters
 
     ***************************************************************************/
 
-    public int opApply ( scope int delegate ( ref istring id, ref Counter counter ) dg )
+    public int opApply ( scope int delegate ( ref string id, ref Counter counter ) dg )
     {
         foreach (id, counter; this.counters)
         {
@@ -161,7 +161,7 @@ version ( unittest )
         scope sc = new RecordActionCounters(["eggs"[], "bacon", "spam"]);
 
         void testCounters ( Counter eggs, Counter bacon, Counter spam,
-                            istring file = __FILE__, int line = __LINE__  )
+                            string file = __FILE__, int line = __LINE__  )
         {
             test!("==")(sc["eggs"], eggs, file, line);
             test!("==")(sc["bacon"], bacon, file, line);

--- a/src/swarm/node/protocol/Command.d
+++ b/src/swarm/node/protocol/Command.d
@@ -29,7 +29,7 @@ import ocean.meta.types.Qualifiers;
 
 *******************************************************************************/
 
-public abstract scope class Command : IRequest
+public abstract class Command : IRequest
 {
     /***************************************************************************
 

--- a/src/swarm/node/request/RequestStats.d
+++ b/src/swarm/node/request/RequestStats.d
@@ -281,7 +281,7 @@ public class RequestStats
 
     unittest
     {
-        void checkCounts ( istring name, BucketDistribution dist, ulong[] expected )
+        void checkCounts ( string name, BucketDistribution dist, ulong[] expected )
         {
             auto t = new NamedTest(name);
             size_t i;
@@ -403,7 +403,7 @@ public class RequestStats
             assert(this.counters.active > 0);
             assert(this.counters.active <= this.counters.max_active);
         }
-        body
+        do
         {
             this.counters.active++;
 
@@ -635,7 +635,7 @@ public class RequestStats
 
     ***************************************************************************/
 
-    public ISingleRequestStats[istring] request_stats;
+    public ISingleRequestStats[string] request_stats;
 
 
     /***************************************************************************
@@ -649,7 +649,7 @@ public class RequestStats
 
     ***************************************************************************/
 
-    public void init ( istring rq, bool timing = true )
+    public void init ( string rq, bool timing = true )
     {
         verify(!(rq in this.request_stats), "command stats " ~ rq ~ " initialised twice");
 

--- a/src/swarm/node/storage/listeners/Listeners.d
+++ b/src/swarm/node/storage/listeners/Listeners.d
@@ -380,7 +380,7 @@ unittest
     // `listeners` should contain the elements that are expected in `liset` in
     // order; that is, unique elements sorted ascendingly by object pointer.
     // `name` is the name of the test.
-    void testListenerSet ( istring name, Listener[] listeners ... )
+    void testListenerSet ( string name, Listener[] listeners ... )
     {
         test!(">")(listeners.length, 0);
         foreach (i, listener; listeners[1 .. $])

--- a/src/swarm/node/storage/model/IStorageChannels.d
+++ b/src/swarm/node/storage/model/IStorageChannels.d
@@ -139,7 +139,7 @@ abstract public class IStorageChannelsTemplate ( Storage : IStorageEngine )
         return channel_id in this.channels;
     }
 
-    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+    public alias opBinaryRight ( string op : "in" ) = opIn_r;
 
 
     /***************************************************************************

--- a/src/swarm/util/ExtensibleClass.d
+++ b/src/swarm/util/ExtensibleClass.d
@@ -52,7 +52,7 @@
             // passed as the 'instance' template parameter as a string, and must
             // be mixed in wherever used.
 
-            public template Extension ( istring instance )
+            public template Extension ( string instance )
             {
                 public void trace ( cstring msg )
                 {
@@ -97,7 +97,7 @@
             // passed as the 'instance' template parameter as a string, and must
             // be mixed in wherever used.
 
-            public template Extension ( istring instance )
+            public template Extension ( string instance )
             {
                 public void add ( uint value )
                 {
@@ -229,7 +229,7 @@ public template ExtensibleClass ( Plugins ... )
 
         ***********************************************************************/
 
-        private template MixinPluginExtension ( T, istring instance_name )
+        private template MixinPluginExtension ( T, string instance_name )
         {
             mixin T.Extension!(instance_name);
         }

--- a/src/swarm/util/Hash.d
+++ b/src/swarm/util/Hash.d
@@ -287,7 +287,7 @@ out ( result )
     assert(isHash(result),
            "Resulting hash string isn't valid - " ~ result);
 }
-body
+do
 {
     if (hash.length < HexDigest.length)
     {

--- a/src/swarm/util/RecordBatcher.d
+++ b/src/swarm/util/RecordBatcher.d
@@ -158,7 +158,7 @@ public class RecordBatcher
             assert(!f);
         }
     }
-    body
+    do
     {
         auto size = this.batchedSize(value);
         return this.fits(size, will_never_fit);
@@ -215,7 +215,7 @@ public class RecordBatcher
             assert(!f);
         }
     }
-    body
+    do
     {
         auto size = this.batchedSize(key, value);
         return this.fits(size, will_never_fit);
@@ -418,7 +418,7 @@ public class RecordBatcher
             assert(!f);
         }
     }
-    body
+    do
     {
         if ( extra_bytes > this.batch.dimension )
         {

--- a/src/swarm/util/log/ClientStats.d
+++ b/src/swarm/util/log/ClientStats.d
@@ -82,7 +82,7 @@ public class ClientStats : StatsLog
 
     ***************************************************************************/
 
-    public IClient[istring] clients;
+    public IClient[string] clients;
 
 
     /***************************************************************************
@@ -146,7 +146,7 @@ public class ClientStats : StatsLog
 
     ***************************************************************************/
 
-    public this ( EpollSelectDispatcher epoll, istring file_name,
+    public this ( EpollSelectDispatcher epoll, string file_name,
         time_t period = default_period )
     {
         this(epoll, file_name, null, period);
@@ -168,9 +168,9 @@ public class ClientStats : StatsLog
     ***************************************************************************/
 
     public this ( Application app, EpollSelectDispatcher epoll,
-        istring file_name, time_t period = default_period )
+        string file_name, time_t period = default_period )
     {
-        Appender newAppender ( istring file, Appender.Layout layout )
+        Appender newAppender ( string file, Appender.Layout layout )
         {
             auto stream = new File(file, File.WriteAppending);
 
@@ -201,8 +201,8 @@ public class ClientStats : StatsLog
 
     ***************************************************************************/
 
-    public this ( EpollSelectDispatcher epoll, istring file_name,
-        scope Appender delegate ( istring file, Appender.Layout layout ) appender,
+    public this ( EpollSelectDispatcher epoll, string file_name,
+        scope Appender delegate ( string file, Appender.Layout layout ) appender,
         time_t period = default_period )
     {
         if ( appender is null )
@@ -317,7 +317,7 @@ public class ClientStats : StatsLog
 
     ***************************************************************************/
 
-    private void appendSection ( istring desc ) ( scope void delegate ( IClient client,
+    private void appendSection ( string desc ) ( scope void delegate ( IClient client,
         cstring id, ref bool add_separator ) append_client )
     {
         bool add_separator;
@@ -351,7 +351,7 @@ public class ClientStats : StatsLog
 
     ***************************************************************************/
 
-    private void appendNodeInfoValue ( istring field ) ( IClient client,
+    private void appendNodeInfoValue ( string field ) ( IClient client,
         cstring id, ref bool add_separator )
     {
         foreach ( node_info; client.nodes )

--- a/src/swarm/util/node/log/Stats.d
+++ b/src/swarm/util/node/log/Stats.d
@@ -231,7 +231,7 @@ private class NodeStatsTemplate ( Logger = StatsLog )
 
     ***************************************************************************/
 
-    private void logRequestStats ( istring category )
+    private void logRequestStats ( string category )
         ( RequestStats request_stats )
     {
         struct RequestStats
@@ -416,7 +416,7 @@ version ( unittest )
             }
         }
 
-        void addObject ( istring category, S ) ( cstring id, S str )
+        void addObject ( string category, S ) ( cstring id, S str )
         {
             static assert(is(S == struct));
             foreach ( i, field; str.tupleof )

--- a/src/turtle/env/model/Node.d
+++ b/src/turtle/env/model/Node.d
@@ -34,7 +34,7 @@ import ocean.core.Verify;
 
 *******************************************************************************/
 
-public abstract class Node ( NodeType, istring id ) : ITurtleEnv
+public abstract class Node ( NodeType, string id ) : ITurtleEnv
 {
     import swarm.Const : NodeItem;
     import swarm.neo.AddrPort;


### PR DESCRIPTION
Deprecations fixes in this commit:
- Ocean deprecated istring, just use string;
- body as a keyword is deprecated, use 'do' instead;
- scope as a type constraint is deprecated, remove it;