### PR TITLE
Fix ConnectionBase.d

### DIFF
--- a/src/swarm/neo/connection/ConnectionBase.d
+++ b/src/swarm/neo/connection/ConnectionBase.d
@@ -758,6 +758,7 @@ abstract class ConnectionBase: ISelectClient
     {
         this.socket               = socket;
         this.epoll                = epoll;
+        this.no_delay             = false;
         this.protocol_error_      = new ProtocolError;
         this.parser.e             = this.protocol_error_;
         this.receiver             = new MessageReceiver(this.socket, this.protocol_error_);


### PR DESCRIPTION
See https://github.com/sociomantic-tsunami/swarm/pull/439
```
./src/swarm/neo/connection/ConnectionBase.d(757): Error: constructor `swarm.neo.connection.ConnectionBase.ConnectionBase.this` missing initializer for immutable field `no_delay`
    protected this ( AddressIPSocket!() socket, EpollSelectDispatcher epoll )
              ^
```