### PR TITLE
Fix null deref in FiberSelectWriter unittest

### DIFF
--- a/src/swarm/protocol/FiberSelectWriter.d
+++ b/src/swarm/protocol/FiberSelectWriter.d
@@ -144,7 +144,7 @@ public class FiberSelectWriter : Ocean.BufferedFiberSelectWriter
     {
         void instantiate ()
         {
-            FiberSelectWriter writer;
+            FiberSelectWriter writer = new FiberSelectWriter(null);
             writer.writeArray( [ 1, 2, 3 ] );
         }
     }


### PR DESCRIPTION
Nic didn't spot this, so fixing this test as well.